### PR TITLE
BUILD: Prefix all artifacts with kiit

### DIFF
--- a/src/common/common/build.gradle
+++ b/src/common/common/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
     // /* <slatekit_local>
     if (kiitSetupViaBinary) {
-        compile "dev.kiit:results:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
     } else {
         // */
         compile project(":kiit-result")
@@ -114,7 +114,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/common/context/build.gradle
+++ b/src/common/context/build.gradle
@@ -60,8 +60,8 @@ dependencies {
 
     // /* <slatekit_local>
     if (kiitSetupViaBinary) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
     } else {
         // */
         compile project(":kiit-result")
@@ -115,7 +115,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/common/requests/build.gradle
+++ b/src/common/requests/build.gradle
@@ -61,8 +61,8 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -117,7 +117,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/common/result/build.gradle
+++ b/src/common/result/build.gradle
@@ -105,7 +105,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/common/telemetry/build.gradle
+++ b/src/common/telemetry/build.gradle
@@ -60,10 +60,10 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:requests:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-requests:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -120,7 +120,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/common/utils/build.gradle
+++ b/src/common/utils/build.gradle
@@ -61,8 +61,8 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -117,7 +117,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/connectors/connectors-cli/build.gradle
+++ b/src/connectors/connectors-cli/build.gradle
@@ -67,13 +67,13 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:context:$kiit_version"
-        compile "dev.kiit:utils:$kiit_version"
-        compile "dev.kiit:requests:$kiit_version"
-        compile "dev.kiit:apis:$kiit_version"
-        compile "dev.kiit:cli:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-context:$kiit_version"
+        compile "dev.kiit:kiit-utils:$kiit_version"
+        compile "dev.kiit:kiit-requests:$kiit_version"
+        compile "dev.kiit:kiit-apis:$kiit_version"
+        compile "dev.kiit:kiit-cli:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -133,7 +133,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/connectors/connectors-entities/build.gradle
+++ b/src/connectors/connectors-entities/build.gradle
@@ -67,12 +67,12 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:context:$kiit_version"
-        compile "dev.kiit:utils:$kiit_version"
-        compile "dev.kiit:db:$kiit_version"
-        compile "dev.kiit:entities:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-context:$kiit_version"
+        compile "dev.kiit:kiit-utils:$kiit_version"
+        compile "dev.kiit:kiit-db:$kiit_version"
+        compile "dev.kiit:kiit-entities:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -131,7 +131,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/connectors/connectors-jobs/build.gradle
+++ b/src/connectors/connectors-jobs/build.gradle
@@ -67,15 +67,15 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:actors:$kiit_version"
-        compile "dev.kiit:core:$kiit_version"
-        compile "dev.kiit:context:$kiit_version"
-        compile "dev.kiit:apis:$kiit_version"
-        compile "dev.kiit:jobs:$kiit_version"
-        compile "dev.kiit:connectors-entities:$kiit_version"
-        compile "dev.kiit:providers-aws:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-actors:$kiit_version"
+        compile "dev.kiit:kiit-core:$kiit_version"
+        compile "dev.kiit:kiit-context:$kiit_version"
+        compile "dev.kiit:kiit-apis:$kiit_version"
+        compile "dev.kiit:kiit-jobs:$kiit_version"
+        compile "dev.kiit:kiit-connectors-entities:$kiit_version"
+        compile "dev.kiit:kiit-providers-aws:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -137,7 +137,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/data/data/build.gradle
+++ b/src/data/data/build.gradle
@@ -59,10 +59,10 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:meta:$kiit_version"
-      compile "dev.kiit:query:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-meta:$kiit_version"
+      compile "dev.kiit:kiit-query:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -116,7 +116,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/data/entities/build.gradle
+++ b/src/data/entities/build.gradle
@@ -59,13 +59,13 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:context:$kiit_version"
-      compile "dev.kiit:query:$kiit_version"
-      compile "dev.kiit:meta:$kiit_version"
-      compile "dev.kiit:data:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-context:$kiit_version"
+      compile "dev.kiit:kiit-query:$kiit_version"
+      compile "dev.kiit:kiit-meta:$kiit_version"
+      compile "dev.kiit:kiit-data:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -122,7 +122,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/data/migrations/build.gradle
+++ b/src/data/migrations/build.gradle
@@ -63,11 +63,11 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:data:$kiit_version"
-      compile "dev.kiit:entities:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-data:$kiit_version"
+      compile "dev.kiit:kiit-entities:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -123,7 +123,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/data/query/build.gradle
+++ b/src/data/query/build.gradle
@@ -59,8 +59,8 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -113,7 +113,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/infra/cache/build.gradle
+++ b/src/infra/cache/build.gradle
@@ -60,10 +60,10 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:core:$kiit_version"
-      compile "dev.kiit:telemetry:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-core:$kiit_version"
+      compile "dev.kiit:kiit-telemetry:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -120,7 +120,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/infra/comms/build.gradle
+++ b/src/infra/comms/build.gradle
@@ -61,10 +61,10 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:http:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-http:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -122,7 +122,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/infra/core/build.gradle
+++ b/src/infra/core/build.gradle
@@ -60,9 +60,9 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:utils:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-utils:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -117,7 +117,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/infra/db/build.gradle
+++ b/src/infra/db/build.gradle
@@ -63,8 +63,8 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -117,7 +117,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/internal/actors/build.gradle
+++ b/src/internal/actors/build.gradle
@@ -105,7 +105,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/internal/http/build.gradle
+++ b/src/internal/http/build.gradle
@@ -61,8 +61,8 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -116,7 +116,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/internal/meta/build.gradle
+++ b/src/internal/meta/build.gradle
@@ -61,10 +61,10 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:utils:$kiit_version"
-        compile "dev.kiit:requests:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-utils:$kiit_version"
+        compile "dev.kiit:kiit-requests:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -120,7 +120,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/internal/policy/build.gradle
+++ b/src/internal/policy/build.gradle
@@ -60,9 +60,9 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:telemetry:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-telemetry:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -119,7 +119,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/internal/serialization/build.gradle
+++ b/src/internal/serialization/build.gradle
@@ -60,10 +60,10 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:requests:$kiit_version"
-        compile "dev.kiit:meta:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-requests:$kiit_version"
+        compile "dev.kiit:kiit-meta:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -121,7 +121,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/providers/providers-aws/build.gradle
+++ b/src/providers/providers-aws/build.gradle
@@ -65,9 +65,9 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:core:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-core:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -122,7 +122,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/providers/providers-datadog/build.gradle
+++ b/src/providers/providers-datadog/build.gradle
@@ -68,9 +68,9 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:telemetry:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-telemetry:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -126,7 +126,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/providers/providers-kafka/build.gradle
+++ b/src/providers/providers-kafka/build.gradle
@@ -65,9 +65,9 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:core:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-core:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -123,7 +123,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/providers/providers-logback/build.gradle
+++ b/src/providers/providers-logback/build.gradle
@@ -67,8 +67,8 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -123,7 +123,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/services/apis/build.gradle
+++ b/src/services/apis/build.gradle
@@ -61,13 +61,13 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:requests:$kiit_version"
-      compile "dev.kiit:context:$kiit_version"
-      compile "dev.kiit:meta:$kiit_version"
-      compile "dev.kiit:serialization:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-requests:$kiit_version"
+      compile "dev.kiit:kiit-context:$kiit_version"
+      compile "dev.kiit:kiit-meta:$kiit_version"
+      compile "dev.kiit:kiit-serialization:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -128,7 +128,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/services/app/build.gradle
+++ b/src/services/app/build.gradle
@@ -60,10 +60,10 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:context:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-context:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -120,7 +120,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/services/cli/build.gradle
+++ b/src/services/cli/build.gradle
@@ -60,11 +60,11 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
-      compile "dev.kiit:requests:$kiit_version"
-      compile "dev.kiit:context:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
+      compile "dev.kiit:kiit-requests:$kiit_version"
+      compile "dev.kiit:kiit-context:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -121,7 +121,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/services/jobs/build.gradle
+++ b/src/services/jobs/build.gradle
@@ -58,10 +58,10 @@ dependencies {
 
   // /* <slatekit_local>
   if( kiitSetupViaBinary ) {
-      compile "dev.kiit:results:$kiit_version"
-      compile "dev.kiit:actors:$kiit_version"
-      compile "dev.kiit:common:$kiit_version"
-      compile "dev.kiit:utils:$kiit_version"
+      compile "dev.kiit:kiit-results:$kiit_version"
+      compile "dev.kiit:kiit-actors:$kiit_version"
+      compile "dev.kiit:kiit-common:$kiit_version"
+      compile "dev.kiit:kiit-utils:$kiit_version"
   } else {
       // */
   compile project(":kiit-result")
@@ -117,7 +117,7 @@ publishing {
     gpr(MavenPublication) {
       from(components.java)
       groupId 'dev.kiit'
-      artifactId "${kiitComponentId}"
+      artifactId "kiit-${kiitComponentId}"
       version "${kiitComponentVersion}"
     }
   }

--- a/src/services/server/build.gradle
+++ b/src/services/server/build.gradle
@@ -74,14 +74,14 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:utils:$kiit_version"
-        compile "dev.kiit:requests:$kiit_version"
-        compile "dev.kiit:context:$kiit_version"
-        compile "dev.kiit:telemetry:$kiit_version"
-        compile "dev.kiit:apis:$kiit_version"
-        compile "dev.kiit:serialization:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-utils:$kiit_version"
+        compile "dev.kiit:kiit-requests:$kiit_version"
+        compile "dev.kiit:kiit-context:$kiit_version"
+        compile "dev.kiit:kiit-telemetry:$kiit_version"
+        compile "dev.kiit:kiit-apis:$kiit_version"
+        compile "dev.kiit:kiit-serialization:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -141,7 +141,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/support/generator/build.gradle
+++ b/src/support/generator/build.gradle
@@ -60,11 +60,11 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:utils:$kiit_version"
-        compile "dev.kiit:context:$kiit_version"
-        compile "dev.kiit:apis:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-utils:$kiit_version"
+        compile "dev.kiit:kiit-context:$kiit_version"
+        compile "dev.kiit:kiit-apis:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -123,7 +123,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }

--- a/src/support/integration/build.gradle
+++ b/src/support/integration/build.gradle
@@ -62,22 +62,22 @@ dependencies {
 
     // /* <slatekit_local>
     if( kiitSetupViaBinary ) {
-        compile "dev.kiit:results:$kiit_version"
-        compile "dev.kiit:common:$kiit_version"
-        compile "dev.kiit:context:$kiit_version"
-        compile "dev.kiit:requests:$kiit_version"
-        compile "dev.kiit:meta:$kiit_version"
-        compile "dev.kiit:query:$kiit_version"
-        compile "dev.kiit:cli:$kiit_version"
-        compile "dev.kiit:entities:$kiit_version"
-        compile "dev.kiit:core:$kiit_version"
-        compile "dev.kiit:comms:$kiit_version"
-        compile "dev.kiit:cache:$kiit_version"
-        compile "dev.kiit:apis:$kiit_version"
-        compile "dev.kiit:jobs:$kiit_version"
-        compile "dev.kiit:policy:$kiit_version"
-        compile "dev.kiit:migrations:$kiit_version"
-        compile "dev.kiit:connectors-entities:$kiit_version"
+        compile "dev.kiit:kiit-results:$kiit_version"
+        compile "dev.kiit:kiit-common:$kiit_version"
+        compile "dev.kiit:kiit-context:$kiit_version"
+        compile "dev.kiit:kiit-requests:$kiit_version"
+        compile "dev.kiit:kiit-meta:$kiit_version"
+        compile "dev.kiit:kiit-query:$kiit_version"
+        compile "dev.kiit:kiit-cli:$kiit_version"
+        compile "dev.kiit:kiit-entities:$kiit_version"
+        compile "dev.kiit:kiit-core:$kiit_version"
+        compile "dev.kiit:kiit-comms:$kiit_version"
+        compile "dev.kiit:kiit-cache:$kiit_version"
+        compile "dev.kiit:kiit-apis:$kiit_version"
+        compile "dev.kiit:kiit-jobs:$kiit_version"
+        compile "dev.kiit:kiit-policy:$kiit_version"
+        compile "dev.kiit:kiit-migrations:$kiit_version"
+        compile "dev.kiit:kiit-connectors-entities:$kiit_version"
     } else {
         // */
     compile project(":kiit-result")
@@ -146,7 +146,7 @@ publishing {
         gpr(MavenPublication) {
             from(components.java)
             groupId 'dev.kiit'
-            artifactId "${kiitComponentId}"
+            artifactId "kiit-${kiitComponentId}"
             version "${kiitComponentVersion}"
         }
     }


### PR DESCRIPTION
## Overview
Prefix all published artifacts with `Kiit` such as `kiit-results` instead of `results`. 

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
Updated all gradle files to reference the artifacts correctly

## Design
n/a

## Notes
n/a

## Pending
n/a

## Tests
n/a
