### PR TITLE
UPGRADE: Gradle scripts

### DIFF
--- a/src/common/common/build.gradle
+++ b/src/common/common/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/common/context/build.gradle
+++ b/src/common/context/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/common/requests/build.gradle
+++ b/src/common/requests/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/common/result/build.gradle
+++ b/src/common/result/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/common/telemetry/build.gradle
+++ b/src/common/telemetry/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/common/utils/build.gradle
+++ b/src/common/utils/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/common/utils/gradle/wrapper/gradle-wrapper.properties
+++ b/src/common/utils/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/connectors/connectors-cli/build.gradle
+++ b/src/connectors/connectors-cli/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/connectors/connectors-entities/build.gradle
+++ b/src/connectors/connectors-entities/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/connectors/connectors-jobs/build.gradle
+++ b/src/connectors/connectors-jobs/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/data/data/build.gradle
+++ b/src/data/data/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/data/entities/build.gradle
+++ b/src/data/entities/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/data/migrations/build.gradle
+++ b/src/data/migrations/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/data/query/build.gradle
+++ b/src/data/query/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/infra/cache/build.gradle
+++ b/src/infra/cache/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/infra/comms/build.gradle
+++ b/src/infra/comms/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/infra/core/build.gradle
+++ b/src/infra/core/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/infra/db/build.gradle
+++ b/src/infra/db/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/internal/actors/build.gradle
+++ b/src/internal/actors/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/internal/http/build.gradle
+++ b/src/internal/http/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/internal/meta/build.gradle
+++ b/src/internal/meta/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/internal/policy/build.gradle
+++ b/src/internal/policy/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/internal/serialization/build.gradle
+++ b/src/internal/serialization/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/lib/kotlin/kiit/build.gradle
+++ b/src/lib/kotlin/kiit/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../../version.txt').text
-    ext.kiit_version_beta = new File('../../../version-beta.txt').text
+    ext.kiit_version = file('../../../version.txt').text
+    ext.kiit_version_beta = file('../../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -36,10 +36,10 @@ repositories {
     jcenter()
     mavenCentral()
     maven {
-        url "https://maven.pkg.github.com/slatekit/slatekit"
+        url "https://maven.pkg.github.com/slatekit/kiit"
         credentials {
-            username = System.getenv('SLATEKIT_INSTALL_ACTOR')
-            password = System.getenv('SLATEKIT_INSTALL_TOKEN')
+            username = System.getenv('KIIT_INSTALL_ACTOR')
+            password = System.getenv('KIIT_INSTALL_TOKEN')
         }
     }
 }

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -1,8 +1,8 @@
 
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.slatekit_version = new File('../../version.txt').text
-    ext.slatekit_version_beta = new File('../../version-beta.txt').text
+    ext.slatekit_version = file('../../version.txt').text
+    ext.slatekit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         mavenCentral()

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/StatusTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/StatusTests.kt
@@ -6,11 +6,28 @@ import kiit.results.*
 class StatusTests {
 
     @Test
-    fun can_build_basic(){
+    fun can_build_basic_passed_category(){
         val status = Passed.Succeeded("SUCCESS", 1, "success")
         Assert.assertEquals("SUCCESS", status.name)
         Assert.assertEquals(1, status.code)
         Assert.assertEquals("success", status.desc)
+        Assert.assertEquals(true, status.success)
+    }
+
+
+    @Test
+    fun can_build_basic_failed_category(){
+        fun validate(status:Failed, name:String, code:Int, desc:String) {
+            Assert.assertEquals(name, status.name)
+            Assert.assertEquals(code, status.code)
+            Assert.assertEquals(desc, status.desc)
+            Assert.assertEquals(false, status.success)
+        }
+        validate(Failed.Ignored("IGNORED", 2, "ignored"), "IGNORED", 2, "ignored")
+        validate(Failed.Invalid("INVALID", 3, "invalid"), "INVALID", 3, "invalid")
+        validate(Failed.Denied ("DENIED" , 4, "denied" ), "DENIED" , 4, "denied" )
+        validate(Failed.Errored("ERRORED", 5, "errored"), "ERRORED", 5, "errored")
+        validate(Failed.Unknown("UNKNOWN", 6, "unknown"), "UNKNOWN", 6, "unknown")
     }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/SampleAnnoApi.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/SampleAnnoApi.kt
@@ -95,6 +95,4 @@ class SampleAnnoApi(val context: AppEntContext) {
 
     @Action(desc = "accepts a smart string of email", roles= [Roles.GUEST])
     fun smartStringEmail(text: Email): String = "${text.value}"
-
-
 }

--- a/src/providers/providers-aws/build.gradle
+++ b/src/providers/providers-aws/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/providers/providers-datadog/build.gradle
+++ b/src/providers/providers-datadog/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/providers/providers-kafka/build.gradle
+++ b/src/providers/providers-kafka/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/providers/providers-logback/build.gradle
+++ b/src/providers/providers-logback/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/services/apis/build.gradle
+++ b/src/services/apis/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/services/app/build.gradle
+++ b/src/services/app/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/services/cli/build.gradle
+++ b/src/services/cli/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/services/jobs/build.gradle
+++ b/src/services/jobs/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.6.20'
-  ext.kiit_version = new File('../../version.txt').text
-  ext.kiit_version_beta = new File('../../version-beta.txt').text
+  ext.kiit_version = file('../../version.txt').text
+  ext.kiit_version_beta = file('../../version-beta.txt').text
 
   repositories {
     jcenter()

--- a/src/services/server/build.gradle
+++ b/src/services/server/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
     ext.ktor_version = '1.6.8'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/support/generator/build.gradle
+++ b/src/support/generator/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()

--- a/src/support/integration/build.gradle
+++ b/src/support/integration/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.6.20'
-    ext.kiit_version = new File('../../version.txt').text
-    ext.kiit_version_beta = new File('../../version-beta.txt').text
+    ext.kiit_version = file('../../version.txt').text
+    ext.kiit_version_beta = file('../../version-beta.txt').text
 
     repositories {
         jcenter()


### PR DESCRIPTION
## Overview
Upgrade gradle to `8.2.1`

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
Gradle `8.2.1` local usage.

## Design
1. moved load of file to `file('.../path').text` in gradle

## Notes
1. fixed gradle and package loading in unit-tests

## Pending
n/a

## Tests
1. added minor additional tests for kiit-result status codes
