### PR TITLE
BUILD: Update runtimes for build/running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+# MySql - docker compose up -d
+  db:
+    container_name: mysql-8
+    image: mysql:8.0.35
+    command: mysqld --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: 12345qwert
+      MYSQL_DATABASE: kiit
+    ports:
+      - '3306:3306'
+    volumes:
+      - db-volume:/var/lib/mysql
+      - './install/db/mysql/3.x:/docker-entrypoint-initdb.d'
+
+volumes:
+  db-volume:

--- a/install/db/mysql/3.x/00-setup-01-unittests.sql
+++ b/install/db/mysql/3.x/00-setup-01-unittests.sql
@@ -1,0 +1,47 @@
+create table `sample_entity` ( 
+`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,  
+`test_string` NVARCHAR(30) NOT NULL,  
+`test_string_enc` NVARCHAR(100) NOT NULL,  
+`test_bool` BIT NOT NULL,  
+`test_short` SMALLINT NOT NULL,  
+`test_int` INTEGER NOT NULL,  
+`test_long` BIGINT NOT NULL,  
+`test_float` FLOAT NOT NULL,  
+`test_double` DOUBLE NOT NULL,  
+`test_enum` INTEGER NOT NULL,  
+`test_localdate` DATE NOT NULL,  
+`test_localtime` TIME NOT NULL,  
+`test_localdatetime` DATETIME NOT NULL,  
+`test_zoneddatetime` DATETIME NOT NULL,  
+`test_uuid` NVARCHAR(50) NOT NULL,  
+`test_uniqueid` NVARCHAR(50) NOT NULL,  
+`test_object_addr` NVARCHAR(40) NOT NULL,  
+`test_object_city` NVARCHAR(30) NOT NULL,  
+`test_object_state` NVARCHAR(20) NOT NULL,  
+`test_object_country` INTEGER NOT NULL,  
+`test_object_zip` NVARCHAR(5) NOT NULL,  
+`test_object_ispobox` BIT NOT NULL );
+
+create table IF NOT EXISTS `User5` (
+`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+`email` NVARCHAR(100) NOT NULL,
+`isActive` BIT NOT NULL,
+`level` INTEGER NOT NULL,
+`salary` DOUBLE NOT NULL,
+`createdat` DATETIME NOT NULL,
+`createdby` BIGINT NOT NULL,
+`updatedat` DATETIME NOT NULL,
+`updatedby` BIGINT NOT NULL,
+`uniqueid` NVARCHAR(50) NOT NULL
+);
+
+create table IF NOT EXISTS `Member` (
+`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+`groupid` BIGINT NOT NULL,
+`userid` BIGINT NOT NULL
+);
+
+create table IF NOT EXISTS `Group` (
+`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+`name` NVARCHAR(30) NOT NULL
+);

--- a/src/common/common/build.gradle
+++ b/src/common/common/build.gradle
@@ -59,13 +59,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if (kiitSetupViaBinary) {
         implementation "dev.kiit:kiit-results:$kiit_version"
     } else {
         // */
         implementation project(":kiit-result")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/common/common/build.gradle
+++ b/src/common/common/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/common/common/gradle/wrapper/gradle-wrapper.properties
+++ b/src/common/common/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 22 15:51:04 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/common/context/build.gradle
+++ b/src/common/context/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if (kiitSetupViaBinary) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -66,7 +66,7 @@ dependencies {
         // */
         implementation project(":kiit-result")
         implementation project(":kiit-common")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/common/context/build.gradle
+++ b/src/common/context/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/common/requests/build.gradle
+++ b/src/common/requests/build.gradle
@@ -60,7 +60,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -68,7 +68,7 @@ dependencies {
       // */
   implementation project(":kiit-result")
   implementation project(":kiit-common")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/common/requests/build.gradle
+++ b/src/common/requests/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/common/requests/gradle/wrapper/gradle-wrapper.properties
+++ b/src/common/requests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/common/result/build.gradle
+++ b/src/common/result/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/common/result/gradle/wrapper/gradle-wrapper.properties
+++ b/src/common/result/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/common/telemetry/build.gradle
+++ b/src/common/telemetry/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -70,7 +70,7 @@ dependencies {
   implementation project(":kiit-common")
   implementation project(":kiit-utils")
   implementation project(":kiit-requests")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/common/telemetry/build.gradle
+++ b/src/common/telemetry/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/common/telemetry/gradle/wrapper/gradle-wrapper.properties
+++ b/src/common/telemetry/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/common/utils/build.gradle
+++ b/src/common/utils/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -67,7 +67,7 @@ dependencies {
       // */
   implementation project(":kiit-result")
   implementation project(":kiit-common")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/common/utils/build.gradle
+++ b/src/common/utils/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/common/utils/src/main/kotlin/kiit/utils/writer/WebWriter.kt
+++ b/src/common/utils/src/main/kotlin/kiit/utils/writer/WebWriter.kt
@@ -56,6 +56,8 @@ class WebWriter : Writer {
             TextType.NoFormat -> writeTag("", mode.format(msg), endLine, "")
             TextType.NewLine -> buffer.append(NEWLINE)
             TextType.Tab -> buffer.append(TAB)
+            TextType.Label -> writeTag("span", mode.format(msg), endLine, "color:Black ")
+            TextType.Raw -> writeTag("span", mode.format(msg), endLine, "color:Black ")
         }
     }
 

--- a/src/connectors/connectors-cli/build.gradle
+++ b/src/connectors/connectors-cli/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -83,7 +83,7 @@ dependencies {
     implementation project(":kiit-requests")
     implementation project(":kiit-apis")
     implementation project(":kiit-cli")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/connectors/connectors-cli/build.gradle
+++ b/src/connectors/connectors-cli/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/connectors/connectors-entities/build.gradle
+++ b/src/connectors/connectors-entities/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -81,7 +81,7 @@ dependencies {
     implementation project(":kiit-utils")
     implementation project(":kiit-db")
     implementation project(":kiit-entities")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/connectors/connectors-entities/build.gradle
+++ b/src/connectors/connectors-entities/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/connectors/connectors-jobs/build.gradle
+++ b/src/connectors/connectors-jobs/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -89,7 +89,7 @@ dependencies {
     implementation project(":kiit-jobs")
     implementation project(":connectors-entities")
     implementation project(":providers-aws")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/connectors/connectors-jobs/build.gradle
+++ b/src/connectors/connectors-jobs/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/data/data/build.gradle
+++ b/src/data/data/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -69,7 +69,7 @@ dependencies {
   implementation project(":kiit-common")
   implementation project(":kiit-meta")
   implementation project(":kiit-query")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // Slate Kit Component info ( for variables for pom / package / etc )

--- a/src/data/data/build.gradle
+++ b/src/data/data/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/data/data/gradle/wrapper/gradle-wrapper.properties
+++ b/src/data/data/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/data/entities/build.gradle
+++ b/src/data/entities/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/data/entities/build.gradle
+++ b/src/data/entities/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -76,7 +76,7 @@ dependencies {
   implementation project(":kiit-data")
   implementation project(":kiit-query")
   implementation project(":kiit-meta")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // Slate Kit Component info ( for variables for pom / package / etc )

--- a/src/data/entities/gradle/wrapper/gradle-wrapper.properties
+++ b/src/data/entities/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/data/migrations/build.gradle
+++ b/src/data/migrations/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/data/migrations/build.gradle
+++ b/src/data/migrations/build.gradle
@@ -61,7 +61,7 @@ dependencies {
   implementation "com.amazonaws:aws-java-sdk-sqs:1.11.100"
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -77,7 +77,7 @@ dependencies {
   implementation project(":kiit-data")
   implementation project(":kiit-entities")
   implementation project(":kiit-meta")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // Slate Kit Component info ( for variables for pom / package / etc )

--- a/src/data/migrations/gradle/wrapper/gradle-wrapper.properties
+++ b/src/data/migrations/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/data/query/build.gradle
+++ b/src/data/query/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -65,7 +65,7 @@ dependencies {
       // */
   implementation project(":kiit-result")
   implementation project(":kiit-common")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // Slate Kit Component info ( for variables for pom / package / etc )

--- a/src/data/query/build.gradle
+++ b/src/data/query/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/data/query/gradle/wrapper/gradle-wrapper.properties
+++ b/src/data/query/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/infra/cache/build.gradle
+++ b/src/infra/cache/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/infra/cache/build.gradle
+++ b/src/infra/cache/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -70,7 +70,7 @@ dependencies {
   implementation project(":kiit-common")
   implementation project(":kiit-core")
   implementation project(":kiit-telemetry")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/infra/cache/gradle/wrapper/gradle-wrapper.properties
+++ b/src/infra/cache/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/infra/comms/build.gradle
+++ b/src/infra/comms/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -71,7 +71,7 @@ dependencies {
   implementation project(":kiit-common")
   implementation project(":kiit-utils")
   implementation project(":kiit-http")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/infra/comms/build.gradle
+++ b/src/infra/comms/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/infra/comms/gradle/wrapper/gradle-wrapper.properties
+++ b/src/infra/comms/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/infra/core/build.gradle
+++ b/src/infra/core/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -68,7 +68,7 @@ dependencies {
     implementation project(":kiit-result")
     implementation project(":kiit-common")
     implementation project(":kiit-utils")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/infra/core/build.gradle
+++ b/src/infra/core/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/infra/core/gradle/wrapper/gradle-wrapper.properties
+++ b/src/infra/core/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/infra/db/build.gradle
+++ b/src/infra/db/build.gradle
@@ -61,7 +61,7 @@ dependencies {
   implementation "com.amazonaws:aws-java-sdk-sqs:1.11.100"
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -69,7 +69,7 @@ dependencies {
       // */
   implementation project(":kiit-result")
   implementation project(":kiit-common")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // Slate Kit Component info ( for variables for pom / package / etc )

--- a/src/infra/db/build.gradle
+++ b/src/infra/db/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/infra/db/gradle/wrapper/gradle-wrapper.properties
+++ b/src/infra/db/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/infra/db/src/main/kotlin/kiit/db/DbUtils.kt
+++ b/src/infra/db/src/main/kotlin/kiit/db/DbUtils.kt
@@ -54,11 +54,12 @@ object DbUtils {
      *
      * @return
      */
-    fun connect(con: DbCon, settings: DbSettings): Connection {
-        val con = if (con.driver == "com.mysql.jdbc.Driver")
-            DriverManager.getConnection(con.url, con.user, con.pswd)
+    fun connect(dbCon: DbCon, settings: DbSettings): Connection {
+        //val con = if (dbCon.user.isNotEmpty())
+        val con = if (dbCon.driver == "com.mysql.jdbc.Driver")
+            DriverManager.getConnection(dbCon.url, dbCon.user, dbCon.pswd)
         else
-            DriverManager.getConnection(con.url)
+            DriverManager.getConnection(dbCon.url)
         con.autoCommit = settings.autoCommit
         return con
     }

--- a/src/internal/actors/build.gradle
+++ b/src/internal/actors/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/internal/actors/gradle/wrapper/gradle-wrapper.properties
+++ b/src/internal/actors/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/internal/http/build.gradle
+++ b/src/internal/http/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -67,7 +67,7 @@ dependencies {
         // */
     implementation project(":kiit-result")
     implementation project(":kiit-common")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/internal/http/build.gradle
+++ b/src/internal/http/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/internal/meta/build.gradle
+++ b/src/internal/meta/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -71,7 +71,7 @@ dependencies {
     implementation project(":kiit-common")
     implementation project(":kiit-utils")
     implementation project(":kiit-requests")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/internal/meta/build.gradle
+++ b/src/internal/meta/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/internal/policy/build.gradle
+++ b/src/internal/policy/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/internal/policy/build.gradle
+++ b/src/internal/policy/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -68,7 +68,7 @@ dependencies {
   implementation project(":kiit-result")
   implementation project(":kiit-common")
   implementation project(":kiit-telemetry")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/internal/policy/gradle/wrapper/gradle-wrapper.properties
+++ b/src/internal/policy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/internal/serialization/build.gradle
+++ b/src/internal/serialization/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation "com.googlecode.json-simple:json-simple:1.1"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -72,7 +72,7 @@ dependencies {
     implementation project(":kiit-requests")
     implementation project(":kiit-meta")
     implementation project(":kiit-utils")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/internal/serialization/build.gradle
+++ b/src/internal/serialization/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/lib/kotlin/kiit/build.gradle
+++ b/src/lib/kotlin/kiit/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
-    ext.ktor_version = '1.6.8'
+    ext.kotlin_version = '1.8.22'
+    ext.ktor_version = '2.3.12'
     ext.kiit_version = file('../../../version.txt').text
     ext.kiit_version_beta = file('../../../version-beta.txt').text
 
@@ -64,8 +64,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
     implementation "io.ktor:ktor-server-netty:$ktor_version"
-    implementation "io.ktor:ktor-metrics:$ktor_version"
-//    implementation "mysql:mysql-connector-java:5.1.48"
+    //implementation "mysql:mysql-connector-java:5.1.48"
+    implementation "mysql:mysql-connector-java:8.0.28"
 //    implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
@@ -107,6 +107,7 @@ dependencies {
     implementation project(":kiit-utils")
     implementation project(":kiit-context")
     implementation project(":kiit-app")
+    implementation project(":kiit-db")
     implementation project(":kiit-apis")
     implementation project(":kiit-cli")
     implementation project(":kiit-meta")

--- a/src/lib/kotlin/kiit/build.gradle
+++ b/src/lib/kotlin/kiit/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 //    implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:results:$kiit_version"
         implementation "dev.kiit:common:$kiit_version"
@@ -135,7 +135,7 @@ dependencies {
 //        implementation project(":kiit-integration")
         implementation project(":kiit-server")
 //        implementation project(":slatekit-samples")
-    } //</slatekit_local>
+    } //</kiit_local>
 //    implementation project(":slatekit-examples")
 //    implementation project(":slatekit-samples")
     implementation project(":kiit-tests")

--- a/src/lib/kotlin/kiit/gradle/wrapper/gradle-wrapper.properties
+++ b/src/lib/kotlin/kiit/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Feb 24 18:15:07 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/lib/kotlin/kiit/src/main/kotlin/kiit/Server.kt
+++ b/src/lib/kotlin/kiit/src/main/kotlin/kiit/Server.kt
@@ -1,10 +1,10 @@
 package kiit
 
 // Ktor
-import io.ktor.application.ApplicationCall
-import io.ktor.application.call
-import io.ktor.routing.get
-import io.ktor.routing.routing
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kiit.apis.*

--- a/src/lib/kotlin/kiit/src/main/resources/templates/kiit/common/files/gradle-wrapper.properties
+++ b/src/lib/kotlin/kiit/src/main/resources/templates/kiit/common/files/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Jan 14 08:18:24 EST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation group: 'com.h2database', name: 'h2'        , version: '1.4.200'
     implementation group: 'org.xerial'    , name:'sqlite-jdbc', version:'3.8.11.2'
     //implementation "com.h2database:h2:1.4.200"
-    implementation 'org.koin:koin-core:2.0.0-rc-2'
+    implementation 'io.insert-koin:koin-core:3.5.6'
     implementation "org.json:json:20230227"
     //implementation group: 'org.json', name: 'json', version: '20201115'
 

--- a/src/lib/kotlin/slatekit-tests/build.gradle
+++ b/src/lib/kotlin/slatekit-tests/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.slatekit_version = file('../../version.txt').text
     ext.slatekit_version_beta = file('../../version-beta.txt').text
 

--- a/src/lib/kotlin/slatekit-tests/gradle/wrapper/gradle-wrapper.properties
+++ b/src/lib/kotlin/slatekit-tests/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/EntitySetup.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/EntitySetup.kt
@@ -33,7 +33,7 @@ object EntitySetup {
     }
 
     fun con(): DbCon {
-        val con = Confs.readDbCon(TestApp::class.java, dbConfPath)!!
+        val con = DbConString(Vendor.MySql, "jdbc:mysql://localhost/kiit", "root", "12345qwert") //Confs.readDbCon(TestApp::class.java, dbConfPath)!!
         return con
     }
 
@@ -45,7 +45,7 @@ object EntitySetup {
     }
 
     fun realDb(): Entities {
-        val con = Confs.readDbCon(TestApp::class.java, dbConfPath)!!
+        val con = con() //Confs.readDbCon(TestApp::class.java, dbConfPath)!!
         val dbs = Connections.of(con)
         val entities = Entities({ con -> Db.of(con) }, dbs, MyEncryptor)
         return entities

--- a/src/providers/providers-aws/build.gradle
+++ b/src/providers/providers-aws/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -73,7 +73,7 @@ dependencies {
     implementation project(":kiit-result")
     implementation project(":kiit-common")
     implementation project(":kiit-core")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/providers/providers-aws/build.gradle
+++ b/src/providers/providers-aws/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/providers/providers-aws/gradle/wrapper/gradle-wrapper.properties
+++ b/src/providers/providers-aws/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/providers/providers-datadog/build.gradle
+++ b/src/providers/providers-datadog/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/providers/providers-datadog/build.gradle
+++ b/src/providers/providers-datadog/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -76,7 +76,7 @@ dependencies {
     implementation project(":kiit-result")
     implementation project(":kiit-common")
     implementation project(":kiit-telemetry")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/providers/providers-kafka/build.gradle
+++ b/src/providers/providers-kafka/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'org.threeten:threetenbp:1.3.8'
     implementation 'org.apache.kafka:kafka-clients:2.4.0'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -73,7 +73,7 @@ dependencies {
     implementation project(":kiit-result")
     implementation project(":kiit-common")
     implementation project(":kiit-core")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/providers/providers-kafka/build.gradle
+++ b/src/providers/providers-kafka/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/providers/providers-logback/build.gradle
+++ b/src/providers/providers-logback/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -73,7 +73,7 @@ dependencies {
         // */
     implementation project(":kiit-result")
     implementation project(":kiit-common")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/providers/providers-logback/build.gradle
+++ b/src/providers/providers-logback/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/services/apis/build.gradle
+++ b/src/services/apis/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -77,7 +77,7 @@ dependencies {
   implementation project(":kiit-context")
   implementation project(":kiit-meta")
   implementation project(":kiit-serialization")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/services/apis/build.gradle
+++ b/src/services/apis/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/services/apis/gradle/wrapper/gradle-wrapper.properties
+++ b/src/services/apis/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/services/app/build.gradle
+++ b/src/services/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -70,7 +70,7 @@ dependencies {
   implementation project(":kiit-common")
   implementation project(":kiit-utils")
   implementation project(":kiit-context")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/services/app/build.gradle
+++ b/src/services/app/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/services/app/gradle/wrapper/gradle-wrapper.properties
+++ b/src/services/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/services/cli/build.gradle
+++ b/src/services/cli/build.gradle
@@ -58,7 +58,7 @@ dependencies {
   implementation 'com.squareup.okhttp3:okhttp:3.9.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-common:$kiit_version"
@@ -72,7 +72,7 @@ dependencies {
   implementation project(":kiit-utils")
   implementation project(":kiit-requests")
   implementation project(":kiit-context")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/services/cli/build.gradle
+++ b/src/services/cli/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/services/cli/gradle/wrapper/gradle-wrapper.properties
+++ b/src/services/cli/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/services/jobs/build.gradle
+++ b/src/services/jobs/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
   implementation 'org.threeten:threetenbp:1.3.8'
 
-  // /* <slatekit_local>
+  // /* <kiit_local>
   if( kiitSetupViaBinary ) {
       implementation "dev.kiit:kiit-results:$kiit_version"
       implementation "dev.kiit:kiit-actors:$kiit_version"
@@ -69,7 +69,7 @@ dependencies {
   implementation project(":kiit-actors")
   implementation project(":kiit-common")
   implementation project(":kiit-utils")
-  } //</slatekit_local>
+  } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/services/jobs/build.gradle
+++ b/src/services/jobs/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.6.20'
+  ext.kotlin_version = '1.8.22'
   ext.kiit_version = file('../../version.txt').text
   ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/services/server/build.gradle
+++ b/src/services/server/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
-    ext.ktor_version = '1.6.8'
+    ext.kotlin_version = '1.8.22'
+    ext.ktor_version = '2.3.12'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 
@@ -53,9 +53,9 @@ repositories {
 ext.kiitSetupViaBinary = System.getenv('KIIT_PROJECT_MODE') != 'sources'
 
 kotlin {
-    experimental {
-        coroutines "enable"
-    }
+//    experimental {
+//        coroutines "enable"
+//    }
 }
 
 dependencies {
@@ -63,7 +63,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "io.ktor:ktor-server-netty:$ktor_version"
-    implementation "io.ktor:ktor-metrics:$ktor_version"
+//    implementation "io.ktor:ktor-metrics:$ktor_version"
 
 
     implementation "org.json:json:20201115"

--- a/src/services/server/build.gradle
+++ b/src/services/server/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation 'org.threeten:threetenbp:1.3.8'
     implementation fileTree(dir: 'lib', include: '*.jar')
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -92,7 +92,7 @@ dependencies {
     implementation project(":kiit-telemetry")
     implementation project(":kiit-apis")
     implementation project(":kiit-serialization")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/services/server/gradle/wrapper/gradle-wrapper.properties
+++ b/src/services/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/services/server/src/main/kotlin/kiit/server/core/RequestHandler.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/core/RequestHandler.kt
@@ -1,7 +1,7 @@
 package kiit.server.core
 
-import io.ktor.application.ApplicationCall
-import io.ktor.routing.Routing
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.routing.Routing
 import kiit.apis.ApiServer
 import kiit.context.Context
 import kiit.telemetry.Diagnostics

--- a/src/services/server/src/main/kotlin/kiit/server/core/ResponseHandler.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/core/ResponseHandler.kt
@@ -1,6 +1,6 @@
 package kiit.server.core
 
-import io.ktor.application.ApplicationCall
+import io.ktor.server.application.ApplicationCall
 import io.ktor.http.HttpStatusCode
 import kiit.common.types.Content
 import kiit.common.types.ContentData

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorHandler.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorHandler.kt
@@ -1,12 +1,12 @@
 package kiit.server.ktor
 
-import io.ktor.application.ApplicationCall
-import io.ktor.application.call
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
 import io.ktor.http.HttpMethod
-import io.ktor.request.httpMethod
-import io.ktor.request.isMultipart
-import io.ktor.request.receiveText
-import io.ktor.routing.*
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.isMultipart
+import io.ktor.server.request.receiveText
+import io.ktor.server.routing.*
 import kiit.apis.ApiServer
 import kiit.context.Context
 import kiit.telemetry.Diagnostics

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorHeaders.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorHeaders.kt
@@ -15,7 +15,7 @@ import kiit.common.convert.Conversions
 import kiit.common.DateTime
 import kiit.common.crypto.Encryptor
 
-import io.ktor.request.*
+import io.ktor.server.request.*
 import org.json.simple.JSONObject
 import kiit.common.values.Metadata
 import kiit.common.Strings

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorMultiParts.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorMultiParts.kt
@@ -1,10 +1,10 @@
 package kiit.server.ktor
 
-import io.ktor.application.ApplicationCall
+import io.ktor.server.application.ApplicationCall
 import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
 import io.ktor.http.content.streamProvider
-import io.ktor.request.receiveMultipart
+import io.ktor.server.request.receiveMultipart
 import kiit.common.types.*
 import kiit.requests.Request
 import kiit.results.Outcome

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorParams.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorParams.kt
@@ -13,8 +13,8 @@
 
 package kiit.server.ktor
 
-import io.ktor.request.ApplicationRequest
-import io.ktor.request.httpMethod
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.request.httpMethod
 import org.json.simple.JSONObject
 import kiit.apis.support.JsonSupport
 import kiit.common.*

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorRequest.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorRequest.kt
@@ -11,10 +11,10 @@
 
 package kiit.server.ktor
 
-import io.ktor.application.ApplicationCall
+import io.ktor.server.application.ApplicationCall
 import kiit.common.*
 import kiit.server.ServerSettings
-import io.ktor.request.*
+import io.ktor.server.request.*
 import kotlinx.coroutines.runBlocking
 //import kotlinx.coroutines.experimental.async
 import kiit.common.types.ContentFile

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorRequests.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorRequests.kt
@@ -1,7 +1,7 @@
 package kiit.server.ktor
 
-import io.ktor.application.ApplicationCall
-import io.ktor.request.uri
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.uri
 import kiit.requests.Request
 
 object KtorRequests {

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorResponse.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorResponse.kt
@@ -11,12 +11,12 @@
 
 package kiit.server.ktor
 
-import io.ktor.application.ApplicationCall
+import io.ktor.server.application.ApplicationCall
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.response.header
-import io.ktor.response.respondBytes
-import io.ktor.response.respondText
+import io.ktor.server.response.header
+import io.ktor.server.response.respondBytes
+import io.ktor.server.response.respondText
 import kiit.common.types.*
 import kiit.serialization.responses.ResponseEncoder
 import kiit.requests.Response

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorResponses.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorResponses.kt
@@ -1,8 +1,8 @@
 package kiit.server.ktor
 
-import io.ktor.application.ApplicationCall
+import io.ktor.server.application.ApplicationCall
 import io.ktor.http.HttpStatusCode
-import io.ktor.response.respondBytes
+import io.ktor.server.response.respondBytes
 import kiit.common.types.ContentData
 import kiit.common.types.ContentTypes
 import kiit.results.*

--- a/src/services/server/src/main/kotlin/kiit/server/ktor/KtorUtils.kt
+++ b/src/services/server/src/main/kotlin/kiit/server/ktor/KtorUtils.kt
@@ -2,7 +2,7 @@ package kiit.server.ktor
 
 import io.ktor.http.HttpMethod
 import io.ktor.http.content.PartData
-import io.ktor.request.*
+import io.ktor.server.request.*
 import org.json.simple.JSONObject
 import org.json.simple.parser.JSONParser
 import kiit.common.ext.toId

--- a/src/support/generator/build.gradle
+++ b/src/support/generator/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -73,7 +73,7 @@ dependencies {
     implementation project(":kiit-utils")
     implementation project(":kiit-context")
     implementation project(":kiit-apis")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/support/generator/build.gradle
+++ b/src/support/generator/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/support/generator/gradle/wrapper/gradle-wrapper.properties
+++ b/src/support/generator/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/support/integration/build.gradle
+++ b/src/support/integration/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.9.0'
     implementation 'org.threeten:threetenbp:1.3.8'
 
-    // /* <slatekit_local>
+    // /* <kiit_local>
     if( kiitSetupViaBinary ) {
         implementation "dev.kiit:kiit-results:$kiit_version"
         implementation "dev.kiit:kiit-common:$kiit_version"
@@ -96,7 +96,7 @@ dependencies {
     implementation project(":kiit-migrations")
     implementation project(":kiit-comms")
     implementation project(":connectors-entities")
-    } //</slatekit_local>
+    } //</kiit_local>
 }
 
 // ==================================================================

--- a/src/support/integration/build.gradle
+++ b/src/support/integration/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     ext.kiit_version = file('../../version.txt').text
     ext.kiit_version_beta = file('../../version-beta.txt').text
 

--- a/src/support/integration/gradle/wrapper/gradle-wrapper.properties
+++ b/src/support/integration/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 26 12:25:13 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Overview
Bump up various runtimes and also setup docker for the tests
1. **kotlin** : Bumped to `1.8.22`
2. **ktor** : Bumped to `2.3.12`
3. **mysql**: Version `8.0.8`

## Ticket(s) 
https://github.com/slatekit/kiit/issues/366

## Links(s)
n/a

## Dependencies
1. **kotlin** : Bumped to `1.8.22`
2. **ktor** : Bumped to `2.3.12`
3. **mysql**: Version `8.0.8`

## Design
1. **build.gradle** : Updated to kotlin in all build scripts
2. **gradle wrapper**: Fixed gradle version in gradle wrapper
3. **ktor** : Fixed package names used in Ktor
4. **docker**: Added mysql docker database in docker compose for use in unit-tests.

## Notes
1. Also fixed the reference to older version of grade. Now using 8.2.1 in the gradle wrapper.

## Pending
n/a

## Tests
Tests ( including the database tests ) can now be run as part of the docker-compose setup
