### PR TITLE
TESTS: Add unit-tests for models with nullable fields

### DIFF
--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_04_Entity_Service_MySql.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_04_Entity_Service_MySql.kt
@@ -27,8 +27,22 @@ import org.junit.Ignore
 import test.setup.Group
 import test.setup.Member
 import test.setup.User5
+import test.setup.UserNullable
 
 /**
+create table IF NOT EXISTS `UserNullable` (
+`id`        BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+`uuid`      NVARCHAR(50) NOT NULL,
+`email`     NVARCHAR(100),
+`isActive`  BIT ,
+`level`     INTEGER,
+`salary`    DOUBLE,
+`createdAt` DATETIME,
+`createdBy` BIGINT,
+`updatedAt` DATETIME,
+`updatedBy` BIGINT
+);
+
 create table IF NOT EXISTS `User5` (
 `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 `email` NVARCHAR(100) NOT NULL,
@@ -74,6 +88,19 @@ open class Data_04_Entity_Service_MySql {
 `uniqueid` NVARCHAR(50) NOT NULL
 );""",
 
+""" create table IF NOT EXISTS `UserNullable` (
+`id`        BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+`uuid`      NVARCHAR(50) NOT NULL,
+`email`     NVARCHAR(100),
+`isActive`  BIT ,
+`level`     INTEGER,
+`salary`    DOUBLE,
+`createdAt` DATETIME,
+`createdBy` BIGINT,
+`updatedAt` DATETIME,
+`updatedBy` BIGINT
+);""",
+
 """create table IF NOT EXISTS `Member` (
 `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 `groupid` BIGINT NOT NULL,
@@ -98,6 +125,7 @@ open class Data_04_Entity_Service_MySql {
         entities.register<Long, User5>(EntityLongId(), vendor = Vendor.MySql) { repo -> UserService(repo) }
         entities.register<Long, Member>(EntityLongId(), vendor = Vendor.MySql) { repo -> EntityService(repo) }
         entities.register<Long, Group>(EntityLongId(), vendor = Vendor.MySql) { repo -> EntityService(repo) }
+        entities.register<Long, UserNullable>(EntityLongId(), vendor = Vendor.MySql) { repo -> EntityService(repo) }
     }
 
 
@@ -112,6 +140,26 @@ open class Data_04_Entity_Service_MySql {
             Assert.assertTrue(User5?.isActive == true)
             Assert.assertTrue(User5?.level == 35)
             Assert.assertTrue(User5?.salary == 12.34)
+        }
+    }
+
+
+    @Test
+    open fun can_use_model_with_nullable_fields() {
+        runBlocking {
+            val userSvc = entities.getService<Long, UserNullable>()
+            val created = UserNullable()
+            val id = userSvc.create(created)
+            val user = userSvc.getById(id)
+            Assert.assertTrue(user != null)
+            Assert.assertNull(user?.email)
+            Assert.assertNull(user?.isActive)
+            Assert.assertNull(user?.level)
+            Assert.assertNull(user?.salary)
+            Assert.assertNull(user?.createdAt)
+            Assert.assertNull(user?.createdBy)
+            Assert.assertNull(user?.updatedAt)
+            Assert.assertNull(user?.updatedBy)
         }
     }
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/EntitySetup.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/EntitySetup.kt
@@ -22,10 +22,10 @@ import java.util.*
 object EntitySetup {
     val enc = AppEncryptor
     val encrypted = enc.encrypt("abc123")
-    val uuid = "497dea41-8658-4bb7-902c-361014799214"
-    val upid = "usa:314fef51-43a7-496c-be24-520e73758836"
+    const val uuid = "497dea41-8658-4bb7-902c-361014799214"
+    const val upid = "usa:314fef51-43a7-496c-be24-520e73758836"
     val meta = Meta<Long, SampleEntityImmutable>(LongId { m -> m.id }, Table("sample1"))
-    val dbConfPath = "usr://.kiit/common/conf/db.conf"
+    const val dbConfPath = "usr://.kiit/common/conf/db.conf"
 
     fun db(): IDb {
         val con = con()

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/UserNormal.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/UserNormal.kt
@@ -168,3 +168,49 @@ data class User5(
         return this.copy(id = id)
     }
 }
+
+
+
+data class UserNullable(
+    @property:Id()
+    override val id: Long = 0,
+
+    @property:Column(length = 50, required = true)
+    val uuid: String = Random.uuid(),
+
+    @property:Column(length = 100, required = false)
+    val email: String? = null,
+
+    @property:Column(required = false)
+    val isActive: Boolean? = null,
+
+    @property:Column(required = false)
+    val level: Int? = null,
+
+    @property:Column(required = false)
+    val salary: Double? = null,
+
+    @property:Column(required = false)
+    val createdAt: DateTime? = null,
+
+    @property:Column(required = false)
+    val createdBy: Long? = null,
+
+    @property:Column(required = false)
+    val updatedAt: DateTime? = null,
+
+    @property:Column(required = false)
+    val updatedBy: Long? = null
+) : EntityWithId<Long>, EntityUpdatable<Long, UserNullable> {
+
+    override fun isPersisted(): Boolean = id > 0
+
+    /**
+     * sets the id on the entity and returns the entity with updated id.
+     * @param id
+     * @return
+     */
+    override fun withId(id: Long): UserNullable {
+        return this.copy(id = id)
+    }
+}


### PR DESCRIPTION
## Overview
Added unit-tests for data models with all nullable fields.
This is to test entities where fields can be nullable for almost any datatype (`int, long, boolean, string, datetime, etc`)

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
Tests only. No code / logic changes

## Notes
n/a

## Pending
n/a

## Tests
Added 1 unit-test for this.
