### PR TITLE
feature: Updated Router new API versioning approach

### DIFF
--- a/src/connectors/connectors-cli/src/main/kotlin/kiit/connectors/cli/CliApi.kt
+++ b/src/connectors/connectors-cli/src/main/kotlin/kiit/connectors/cli/CliApi.kt
@@ -16,6 +16,7 @@ package kiit.connectors.cli
 import kiit.apis.ApiServer
 import kiit.apis.routes.Api
 import kiit.apis.core.Part
+import kiit.apis.routes.Areas
 import kiit.apis.routes.VersionAreas
 import kiit.cli.CLI
 import kiit.cli.CliRequest
@@ -55,7 +56,7 @@ open class CliApi(
     val ctx: Context,
     val auth: kiit.apis.core.Auth,
     settings: CliSettings = CliSettings(),
-    routes: List<VersionAreas> = listOf(),
+    routes: Areas,
     serializer: (Any?, ContentType) -> Content,
     val metaTransform: ((Map<String, Any>) -> List<Pair<String, String>>)? = null
 ) : CLI(settings, ctx.info, ctx.dirs, serializer = serializer) {

--- a/src/connectors/connectors-cli/src/main/kotlin/kiit/connectors/cli/CliApi.kt
+++ b/src/connectors/connectors-cli/src/main/kotlin/kiit/connectors/cli/CliApi.kt
@@ -17,7 +17,6 @@ import kiit.apis.ApiServer
 import kiit.apis.routes.Api
 import kiit.apis.core.Part
 import kiit.apis.routes.Areas
-import kiit.apis.routes.VersionAreas
 import kiit.cli.CLI
 import kiit.cli.CliRequest
 import kiit.cli.CliResponse

--- a/src/lib/kotlin/kiit/src/main/kotlin/kiit/KiitServices.kt
+++ b/src/lib/kotlin/kiit/src/main/kotlin/kiit/KiitServices.kt
@@ -1,8 +1,6 @@
 package kiit
 
-import kiit.apis.SetupType
-import kiit.apis.routes.Api
-import kiit.apis.setup.GlobalVersion
+import kiit.apis.setup.ApiSetup
 import kiit.apis.setup.api
 import kiit.apis.tools.code.CodeGenApi
 import kiit.common.conf.Conf
@@ -14,18 +12,16 @@ interface KiitServices {
 
     val ctx: Context
 
-    fun apis(settings:Conf): List<GlobalVersion> {
+    fun apis(settings:Conf): List<ApiSetup> {
         // APIs
         val toolSettings = ToolSettings(settings.getString("kiit.version"), settings.getString("kiit.version.beta"), "logs/logback.log")
         val buildSettings = BuildSettings(settings.getString("kotlin.version"))
         val logger = ctx.logs.getLogger("gen")
         val generator = GeneratorApi(ctx, GeneratorService(ctx, settings, Kiit::class.java, GeneratorSettings(toolSettings, buildSettings), logger = logger))
         return listOf(
-            GlobalVersion("0", listOf(
                 api(GeneratorApi::class, generator),
                 api(DocApi::class, DocApi(ctx)),
                 api(CodeGenApi::class, CodeGenApi())
             )
-        ))
     }
 }

--- a/src/lib/kotlin/kiit/src/main/kotlin/kiit/Server.kt
+++ b/src/lib/kotlin/kiit/src/main/kotlin/kiit/Server.kt
@@ -9,8 +9,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kiit.apis.*
 import kiit.apis.core.Auth
-import kiit.apis.core.Meta
-import kiit.apis.setup.GlobalVersion
+import kiit.apis.setup.ApiSetup
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 
@@ -93,20 +92,11 @@ class Server(val ctx: Context)  {
     }
 
 
-    fun apis(): List<GlobalVersion> {
+    fun apis(): List<ApiSetup> {
         val apis = listOf(
-                GlobalVersion("v0",
-                    listOf(
-                        api(SampleFiles3Api::class, SampleFiles3Api()),
-                        api(SampleVersionApi::class, SampleVersionApi("0")),
-                    )
-                ),
-                GlobalVersion("v1",
-                    listOf(
-                        api(SampleVersionApi::class, SampleVersionApi("1")),
-                    )
-                )
-            )
+            api(SampleFiles3Api::class, SampleFiles3Api()),
+            api(SampleVersionApi::class, SampleVersionApi("1")),
+        )
         return apis
     }
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/ApiTestsBase.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/ApiTestsBase.kt
@@ -18,7 +18,8 @@ import kiit.apis.*
 import kiit.apis.core.Auth
 import kiit.apis.executor.MetaHandler
 import kiit.apis.routes.Areas
-import kiit.apis.routes.VersionAreas
+import kiit.apis.setup.ApiSetup
+import kiit.apis.setup.routes
 import kiit.requests.CommonRequest
 import kiit.common.Source
 import kiit.common.args.Args
@@ -91,15 +92,15 @@ open class ApiTestsBase {
 
     fun getApis(source: Source,
                 auth: Auth? = null,
-                apis: List<VersionAreas> = listOf()): ApiServer {
+                apis: List<ApiSetup> = listOf()): ApiServer {
 
         // 2. apis
-        val container = ApiServer.of(ctx, apis, auth, source)
+        val container = ApiServer.of(ctx, routes(apis), auth, source)
         return container
     }
 
 
-    fun ensureCall(apis: List<VersionAreas> = listOf(),
+    fun ensureCall(apis: List<ApiSetup> = listOf(),
                    protocolCt: String,
                    protocol: String,
                    authMode: String,

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/ApiTestsBase.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/ApiTestsBase.kt
@@ -17,6 +17,7 @@ import org.junit.Assert
 import kiit.apis.*
 import kiit.apis.core.Auth
 import kiit.apis.executor.MetaHandler
+import kiit.apis.routes.Areas
 import kiit.apis.routes.VersionAreas
 import kiit.requests.CommonRequest
 import kiit.common.Source
@@ -135,7 +136,7 @@ open class ApiTestsBase {
     fun checkCall(
         protocol: Source,
         middleware: List<Middleware> = listOf(),
-        routes: List<VersionAreas>,
+        routes: Areas,
         user: Credentials?,
         request: Request,
         response: Response<*>,

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
@@ -188,7 +188,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
         )
         // Check defaults
         Assert.assertTrue(router.containsArea(area = "tests"))
-        Assert.assertTrue(router.containsApi(area = "tests", api = "defaults"))
+        Assert.assertTrue(router.containsApi(area = "tests", api = "defaults", version = "1"))
         Assert.assertTrue(router.containsApi(area = "tests", api = "defaults", version = "0"))
         Assert.assertTrue(
             router.containsAction(

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
@@ -114,7 +114,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
             )
         )
 
-        val apiOpt = router.getApi("tests", "overrides", "0")
+        val apiOpt = router.getApi("tests", "overrides", "1")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureOverrideSetup(actions)
@@ -168,7 +168,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
             )
         )
 
-        val actionOpt = router.getAction(Verbs.POST, "tests", "redirects", "1", "adder", "1")
+        val actionOpt = router.getAction(Verbs.POST, "tests", "redirects", "0", "adder", "0")
         Assert.assertNotNull(actionOpt)
         val actions = actionOpt!!
         Assert.assertEquals("tests", actions.area.name)

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
@@ -31,14 +31,11 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     @Test
     fun can_load_routes_from_annotations_with_defaults() {
         val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(SampleAnnotatedApiWithDefaults::class, SampleAnnotatedApiWithDefaults())
-                    )
-                )
+    listOf(
+                api(SampleAnnotatedApiWithDefaults::class, SampleAnnotatedApiWithDefaults())
             )
         )
+
         val apiOpt = router.getApi("tests", "defaults", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
@@ -48,19 +45,16 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     @Test
     fun can_load_routes_from_config_with_defaults() {
         val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(
-                            SampleAnnotatedApiWithDefaults::class,
-                            SampleAnnotatedApiWithDefaults(),
-                            setup = SetupType.Config,
-                            content = JSON_DEFAULTS.trim()
-                        )
-                    )
+        listOf(
+                api(
+                    SampleAnnotatedApiWithDefaults::class,
+                    SampleAnnotatedApiWithDefaults(),
+                    setup = SetupType.Config,
+                    content = JSON_DEFAULTS.trim()
                 )
             )
         )
+
         val apiOpt = router.getApi("tests", "defaults", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
@@ -81,13 +75,13 @@ class Api_001_Loader_Tests : ApiTestsBase() {
         Assert.assertEquals(Access.Public, api.access)
         Assert.assertEquals(true, api.sources.hasAPI())
 
-        Assert.assertEquals("add", actions.items[0].path.action.name)
-        Assert.assertEquals(true , actions.items[0].path.action.roles.isEmpty)
-        Assert.assertEquals(AuthMode.Keyed, actions.items[0].path.action.auth)
-        Assert.assertEquals(Verb.Post     , actions.items[0].path.action.verb)
-        Assert.assertEquals("0"  , actions.items[0].path.action.version)
-        Assert.assertEquals(Access.Public , actions.items[0].path.action.access)
-        Assert.assertEquals(true , actions.items[0].path.action.sources.hasAPI())
+        Assert.assertEquals("add", actions.items[0].action.name)
+        Assert.assertEquals(true , actions.items[0].action.roles.isEmpty)
+        Assert.assertEquals(AuthMode.Keyed, actions.items[0].action.auth)
+        Assert.assertEquals(Verb.Post     , actions.items[0].action.verb)
+        Assert.assertEquals("0"  , actions.items[0].action.version)
+        Assert.assertEquals(Access.Public , actions.items[0].action.access)
+        Assert.assertEquals(true , actions.items[0].action.sources.hasAPI())
         Assert.assertEquals(2    , (actions.items[0].handler as MethodExecutor).call.params.size)
     }
 
@@ -95,15 +89,12 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     @Test
     fun can_load_routes_from_annotations_with_overrides() {
         val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(SampleAnnotatedApiWithOverrides::class, SampleAnnotatedApiWithOverrides())
-                    )
-                )
+    listOf(
+                api(SampleAnnotatedApiWithOverrides::class, SampleAnnotatedApiWithOverrides())
             )
         )
-        val apiOpt = router.getApi("tests", "overrides", "0", "1.0")
+
+        val apiOpt = router.getApi("tests", "overrides", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureOverrideSetup(actions)
@@ -113,20 +104,17 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     @Test
     fun can_load_routes_from_config_with_overrides() {
         val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(
-                            SampleApiWithConfigSetup::class,
-                            SampleApiWithConfigSetup(),
-                            setup = SetupType.Config,
-                            content = JSON_OVERRIDES.trim()
-                        )
-                    )
+        listOf(
+                api(
+                    SampleApiWithConfigSetup::class,
+                    SampleApiWithConfigSetup(),
+                    setup = SetupType.Config,
+                    content = JSON_OVERRIDES.trim()
                 )
             )
         )
-        val apiOpt = router.getApi("tests", "overrides", "0", "1.0")
+
+        val apiOpt = router.getApi("tests", "overrides", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureOverrideSetup(actions)
@@ -151,15 +139,15 @@ class Api_001_Loader_Tests : ApiTestsBase() {
         Assert.assertEquals("apiPolicy1", api.policies[0])
         Assert.assertEquals("apiPolicy2", api.policies[1])
 
-        val action = actions.items[0].path.action
-        Assert.assertEquals("adder", actions.items[0].path.action.name)
-        Assert.assertEquals(true, actions.items[0].path.action.roles.contains("user"))
-        Assert.assertEquals(AuthMode.Keyed, actions.items[0].path.action.auth)
-        Assert.assertEquals(Verb.Put, actions.items[0].path.action.verb)
-        Assert.assertEquals("1", actions.items[0].path.action.version)
-        Assert.assertEquals(Access.Public, actions.items[0].path.action.access)
-        Assert.assertEquals(true, actions.items[0].path.action.sources.hasAPI())
-        Assert.assertEquals(false, actions.items[0].path.action.sources.hasCLI())
+        val action = actions.items[0].action
+        Assert.assertEquals("adder", actions.items[0].action.name)
+        Assert.assertEquals(true, actions.items[0].action.roles.contains("user"))
+        Assert.assertEquals(AuthMode.Keyed, actions.items[0].action.auth)
+        Assert.assertEquals(Verb.Put, actions.items[0].action.verb)
+        Assert.assertEquals("1", actions.items[0].action.version)
+        Assert.assertEquals(Access.Public, actions.items[0].action.access)
+        Assert.assertEquals(true, actions.items[0].action.sources.hasAPI())
+        Assert.assertEquals(false, actions.items[0].action.sources.hasCLI())
         Assert.assertEquals(2, (actions.items[0].handler as MethodExecutor).call.params.size)
         Assert.assertEquals("actionTag1", action.tags[0])
         Assert.assertEquals("actionTag2", action.tags[1])
@@ -170,47 +158,38 @@ class Api_001_Loader_Tests : ApiTestsBase() {
 
     @Test
     fun can_load_routes_with_redirects() {
-        val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(
-                            SampleApiWithConfigSetup::class,
-                            SampleApiWithConfigSetup(),
-                            setup = SetupType.Config,
-                            content = JSON_REDIRECTS.trim()
-                        )
-                    )
+        val router = router(listOf(
+                api(
+                    SampleApiWithConfigSetup::class,
+                    SampleApiWithConfigSetup(),
+                    setup = SetupType.Config,
+                    content = JSON_REDIRECTS.trim()
                 )
             )
         )
-        val actionOpt = router.getAction(Verbs.POST, "tests", "redirects", "adder", version = null)
+
+        val actionOpt = router.getAction(Verbs.POST, "tests", "redirects", "1", "adder", "1")
         Assert.assertNotNull(actionOpt)
         val actions = actionOpt!!
-        Assert.assertEquals("tests", actions.path.area.name)
-        Assert.assertEquals("redirects", actions.path.api.name)
-        Assert.assertEquals("add", actions.path.action.name)
-        Assert.assertEquals(Verb.Post, actions.path.action.verb)
+        Assert.assertEquals("tests", actions.area.name)
+        Assert.assertEquals("redirects", actions.api.name)
+        Assert.assertEquals("add", actions.action.name)
+        Assert.assertEquals(Verb.Post, actions.action.verb)
     }
 
 
     @Test
     fun can_load_routes_and_check_contains() {
         val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(SampleAnnotatedApiWithDefaults::class, SampleAnnotatedApiWithDefaults()),
-                        api(SampleAnnotatedApiWithOverrides::class, SampleAnnotatedApiWithOverrides())
-                    )
-                )
+            listOf(
+                api(SampleAnnotatedApiWithDefaults::class, SampleAnnotatedApiWithDefaults()),
+                api(SampleAnnotatedApiWithOverrides::class, SampleAnnotatedApiWithOverrides())
             )
         )
         // Check defaults
         Assert.assertTrue(router.containsArea(area = "tests"))
-        Assert.assertTrue(router.containsArea(area = "tests", globalVersion = "0"))
         Assert.assertTrue(router.containsApi(area = "tests", api = "defaults"))
-        Assert.assertTrue(router.containsApi(area = "tests", api = "defaults", globalVersion = "0"))
+        Assert.assertTrue(router.containsApi(area = "tests", api = "defaults", version = "0"))
         Assert.assertTrue(
             router.containsAction(
                 verb = Verb.Post.name,
@@ -225,25 +204,23 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 area = "tests",
                 api = "defaults",
                 action = "add",
-                globalVersion = "0"
+                apiVersion = "0",
+                actionVersion = "1"
             )
         )
 
         // Check overrides
         Assert.assertTrue(router.containsArea(area = "tests"))
-        Assert.assertTrue(router.containsArea(area = "tests", globalVersion = "0"))
-        Assert.assertFalse(router.containsArea(area = "tests", globalVersion = "1"))
-        Assert.assertFalse(router.containsApi(area = "tests", api = "overrides", globalVersion = "1", version = "1.0"))
-        Assert.assertTrue(router.containsApi(area = "tests", api = "overrides", globalVersion = "0", version = "1.0"))
-        Assert.assertFalse(router.containsApi(area = "tests", api = "overrides", globalVersion = "0", version = "0.0"))
+        Assert.assertFalse(router.containsApi(area = "tests", api = "overrides", version = "0"))
+        Assert.assertTrue(router.containsApi(area = "tests", api = "overrides", version = "1"))
         Assert.assertFalse(
             router.containsAction(
                 verb = Verb.Post.name,
                 area = "tests",
                 api = "overrides",
                 action = "add",
-                globalVersion = "0",
-                version = "1.0"
+                apiVersion = "0",
+                actionVersion = "1.0"
             )
         )
         Assert.assertFalse(
@@ -252,8 +229,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 area = "tests",
                 api = "overrides",
                 action = "add",
-                globalVersion = "1",
-                version = "1.0"
+                apiVersion = "1",
+                actionVersion = "1.0"
             )
         )
         Assert.assertFalse(
@@ -262,8 +239,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 area = "tests",
                 api = "overrides",
                 action = "add",
-                globalVersion = "0",
-                version = "1.1"
+                apiVersion = "0",
+                actionVersion = "1.1"
             )
         )
         Assert.assertFalse(
@@ -272,8 +249,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 area = "tests",
                 api = "overrides",
                 action = "add",
-                globalVersion = "0",
-                version = "1.1"
+                apiVersion = "0",
+                actionVersion = "1.1"
             )
         )
         Assert.assertTrue(
@@ -282,8 +259,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 area = "tests",
                 api = "overrides",
                 action = "adder",
-                globalVersion = "0",
-                version = "1.1"
+                apiVersion = "0",
+                actionVersion = "1.1"
             )
         )
     }
@@ -291,12 +268,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     @Test
     fun can_load_routes_only_public_and_annotated() {
         val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(SampleAnnotatedTestApi::class, SampleAnnotatedTestApi())
-                    )
-                )
+            listOf(
+                api(SampleAnnotatedTestApi::class, SampleAnnotatedTestApi())
             )
         )
         val apiOpt = router.getApi("tests", "loader", "0")

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
@@ -94,7 +94,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
             )
         )
 
-        val apiOpt = router.getApi("tests", "overrides", "0")
+        val apiOpt = router.getApi("tests", "overrides", "1")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureOverrideSetup(actions)
@@ -188,8 +188,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
         )
         // Check defaults
         Assert.assertTrue(router.containsArea(area = "tests"))
-        Assert.assertTrue(router.containsApi(area = "tests", api = "defaults", version = "1"))
         Assert.assertTrue(router.containsApi(area = "tests", api = "defaults", version = "0"))
+        Assert.assertFalse(router.containsApi(area = "tests", api = "defaults", version = "1"))
         Assert.assertTrue(
             router.containsAction(
                 verb = Verb.Post.name,
@@ -205,7 +205,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 api = "defaults",
                 action = "add",
                 apiVersion = "0",
-                actionVersion = "1"
+                actionVersion = "0"
             )
         )
 
@@ -220,7 +220,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 api = "overrides",
                 action = "add",
                 apiVersion = "0",
-                actionVersion = "1.0"
+                actionVersion = "1"
             )
         )
         Assert.assertFalse(
@@ -230,7 +230,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 api = "overrides",
                 action = "add",
                 apiVersion = "1",
-                actionVersion = "1.0"
+                actionVersion = "1"
             )
         )
         Assert.assertFalse(
@@ -250,7 +250,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 api = "overrides",
                 action = "add",
                 apiVersion = "0",
-                actionVersion = "1.1"
+                actionVersion = "1"
             )
         )
         Assert.assertTrue(
@@ -259,8 +259,8 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 area = "tests",
                 api = "overrides",
                 action = "adder",
-                apiVersion = "0",
-                actionVersion = "1.1"
+                apiVersion = "1",
+                actionVersion = "1"
             )
         )
     }
@@ -392,7 +392,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
               {
                   "name"     : "adder",
                   "verb"     : "post",
-                  "execute"  :  { "type": "redirect", "target": "tests/redirects/add", "globalVersion": "0", "verb": "post" }
+                  "execute"  :  { "type": "redirect", "target": "tests/redirects/add", "version": "0", "verb": "post" }
               },
               {
                   "execute"  :  { "type": "method", "target": "add" }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
@@ -15,7 +15,7 @@ package test.apis
 import org.junit.Assert
 import org.junit.Test
 import kiit.apis.*
-import kiit.apis.routes.Actions
+import kiit.apis.routes.ApiActions
 import kiit.apis.routes.MethodExecutor
 import kiit.apis.setup.*
 import test.setup.*
@@ -62,7 +62,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     }
 
 
-    private fun ensureDefaultSetup(actions: Actions) {
+    private fun ensureDefaultSetup(actions: ApiActions) {
         val api = actions.api
         Assert.assertEquals(1, actions.size)
         Assert.assertEquals("tests", api.area)
@@ -121,7 +121,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
     }
 
 
-    fun ensureOverrideSetup(actions: Actions) {
+    fun ensureOverrideSetup(actions: ApiActions) {
         val api = actions.api
         Assert.assertEquals(1, actions.size)
         Assert.assertEquals("tests", api.area)

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Loader_Tests.kt
@@ -15,7 +15,7 @@ package test.apis
 import org.junit.Assert
 import org.junit.Test
 import kiit.apis.*
-import kiit.apis.routes.ApiActions
+import kiit.apis.routes.Actions
 import kiit.apis.routes.MethodExecutor
 import kiit.apis.setup.*
 import test.setup.*
@@ -39,7 +39,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 )
             )
         )
-        val apiOpt = router.api("tests", "defaults", "0")
+        val apiOpt = router.getApi("tests", "defaults", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureDefaultSetup(actions)
@@ -61,14 +61,14 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 )
             )
         )
-        val apiOpt = router.api("tests", "defaults", "0")
+        val apiOpt = router.getApi("tests", "defaults", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureDefaultSetup(actions)
     }
 
 
-    private fun ensureDefaultSetup(actions: ApiActions) {
+    private fun ensureDefaultSetup(actions: Actions) {
         val api = actions.api
         Assert.assertEquals(1, actions.size)
         Assert.assertEquals("tests", api.area)
@@ -103,7 +103,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 )
             )
         )
-        val apiOpt = router.api("tests", "overrides", "0", "1.0")
+        val apiOpt = router.getApi("tests", "overrides", "0", "1.0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureOverrideSetup(actions)
@@ -126,14 +126,14 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 )
             )
         )
-        val apiOpt = router.api("tests", "overrides", "0", "1.0")
+        val apiOpt = router.getApi("tests", "overrides", "0", "1.0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         ensureOverrideSetup(actions)
     }
 
 
-    fun ensureOverrideSetup(actions: ApiActions) {
+    fun ensureOverrideSetup(actions: Actions) {
         val api = actions.api
         Assert.assertEquals(1, actions.size)
         Assert.assertEquals("tests", api.area)
@@ -184,7 +184,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 )
             )
         )
-        val actionOpt = router.action(Verbs.POST, "tests", "redirects", "adder", version = null)
+        val actionOpt = router.getAction(Verbs.POST, "tests", "redirects", "adder", version = null)
         Assert.assertNotNull(actionOpt)
         val actions = actionOpt!!
         Assert.assertEquals("tests", actions.path.area.name)
@@ -299,7 +299,7 @@ class Api_001_Loader_Tests : ApiTestsBase() {
                 )
             )
         )
-        val apiOpt = router.api("tests", "loader", "0")
+        val apiOpt = router.getApi("tests", "loader", "0")
         Assert.assertNotNull(apiOpt)
         val actions = apiOpt!!
         val api = actions.api

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Router_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Router_Tests.kt
@@ -1,7 +1,6 @@
 package test.apis
 
 import kiit.apis.setup.api
-import kiit.apis.setup.global
 import kiit.apis.setup.router
 import kiit.context.AppContext
 import org.junit.Test
@@ -14,22 +13,18 @@ class Api_001_Router_Tests : ApiTestsBase() {
     @Test
     fun can_load_routes_with_versions() {
         val context = AppContext.simple(Api_001_Router_Tests::class.java, "simple")
-        val router = router(
-            versions = listOf(
-                global(
-                    version = "0", apis = listOf(
-                        api(SampleApi1V1::class, SampleApi1V1(context)),
-                        api(SampleApi2V2::class, SampleApi2V2(context))
-                    )
-                )
+        val router = router(listOf(
+                api(SampleApi1V1::class, SampleApi1V1(context)),
+                api(SampleApi2V2::class, SampleApi2V2(context))
             )
         )
-        router.versions.forEachIndexed { ndx , version ->
-            println("Version ndx = $ndx, name = ${version.name}, version = ${version.version}")
-            version.items.forEachIndexed { ndxArea, area ->
-                println("Area ndx = $ndxArea, name = ${area.name}, version = ${area.name}")
-                area.items.forEachIndexed { ndxApi, api ->
-                    println("Api ndx = $ndxApi, name = ${api.name}, version = ${api.api.version}")
+
+        router.areas.items.forEachIndexed { ndx , area ->
+            println("Version ndx = $ndx, name = ${area.name}")
+            area.items.forEachIndexed { ndxApi, api ->
+                println("Area ndx = $ndxApi, name = ${api.api.name}, version = ${api.api.version}")
+                api.items.forEachIndexed { ndxAction, action ->
+                    println("Action ndx = $ndxAction, name = ${action.action.name}, version = ${action.action.version}")
                 }
             }
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Router_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Router_Tests.kt
@@ -22,9 +22,9 @@ class Api_001_Router_Tests : ApiTestsBase() {
         router.areas.items.forEachIndexed { ndx , area ->
             println("Version ndx = $ndx, name = ${area.name}")
             area.items.forEachIndexed { ndxApi, api ->
-                println("Area ndx = $ndxApi, name = ${api.api.name}, version = ${api.api.version}")
+                println("- Area  ndx = $ndxApi, version = ${api.api.version}, name = ${api.api.name}")
                 api.items.forEachIndexed { ndxAction, action ->
-                    println("Action ndx = $ndxAction, name = ${action.action.name}, version = ${action.action.version}")
+                    println("  - Action  ndx = $ndxAction, version = ${action.action.version}, name = ${action.action.name}, ")
                 }
             }
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Router_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_001_Router_Tests.kt
@@ -1,0 +1,37 @@
+package test.apis
+
+import kiit.apis.setup.api
+import kiit.apis.setup.global
+import kiit.apis.setup.router
+import kiit.context.AppContext
+import org.junit.Test
+import test.setup.SampleApi1V1
+import test.setup.SampleApi2V2
+
+
+class Api_001_Router_Tests : ApiTestsBase() {
+
+    @Test
+    fun can_load_routes_with_versions() {
+        val context = AppContext.simple(Api_001_Router_Tests::class.java, "simple")
+        val router = router(
+            versions = listOf(
+                global(
+                    version = "0", apis = listOf(
+                        api(SampleApi1V1::class, SampleApi1V1(context)),
+                        api(SampleApi2V2::class, SampleApi2V2(context))
+                    )
+                )
+            )
+        )
+        router.versions.forEachIndexed { ndx , version ->
+            println("Version ndx = $ndx, name = ${version.name}, version = ${version.version}")
+            version.items.forEachIndexed { ndxArea, area ->
+                println("Area ndx = $ndxArea, name = ${area.name}, version = ${area.name}")
+                area.items.forEachIndexed { ndxApi, api ->
+                    println("Api ndx = $ndxApi, name = ${api.name}, version = ${api.api.version}")
+                }
+            }
+        }
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_002_Executor_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_002_Executor_Tests.kt
@@ -15,7 +15,6 @@ package test.apis
 import org.junit.Test
 import kiit.apis.*
 import kiit.apis.executor.MetaHandler
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.common.Source
@@ -48,7 +47,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_execute_public_action() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processEmpty.name}", Verbs.POST, mapOf(), mapOf(Pair("code", "1"), Pair("tag", "abc"))),
             response = Success("ok", msg = "no inputs").toResponse()
@@ -60,7 +59,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_execute_with_annotated_action_name() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.checkName", Verbs.POST, mapOf(), mapOf(Pair("name", "hi 123"))),
             response = Success("ok", msg = "hi 123 ok").toResponse()
@@ -73,7 +72,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
         val zone = ZoneId.of("EST")
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processInputs.name}", Verbs.POST, mapOf(), mapOf(
                     Pair("phone", "p1"),
@@ -89,7 +88,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_execute_with_redirect() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleApiWithConfigSetup::class, SampleApiWithConfigSetup(), setup = SetupType.Config, content = Api_001_Loader_Tests.JSON_REDIRECTS))))),
+            routes = routes(listOf(api(SampleApiWithConfigSetup::class, SampleApiWithConfigSetup(), setup = SetupType.Config, content = Api_001_Loader_Tests.JSON_REDIRECTS))),
             user = null,
             request = CommonRequest.path("tests.redirects.adder", Verbs.POST, mapOf(), mapOf(
                 Pair("a" , 1   ),
@@ -104,7 +103,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_execute_with_type_raw_request() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processRequest.name}", Verbs.POST, mapOf(), mapOf(Pair("id", "2"))),
             response = Success("ok", msg = "raw send id: 2").toResponse()
@@ -127,7 +126,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
 
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processCustom.name}", Verbs.POST,
                 mapOf(Pair("name", "c1"), Pair("code", 2)),
@@ -143,7 +142,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_execute_with_type_raw_meta() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processMeta.name}", Verbs.POST, mapOf(Pair("token", "abc")), mapOf(Pair("id", "2"))),
             response = Success("ok", msg = "raw meta token: abc").toResponse()
@@ -155,7 +154,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_execute_with_type_raw_both() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processBoth.name}", Verbs.POST, mapOf(Pair("token", "abc")), mapOf(Pair("id", "2"))),
             response = Success("ok", msg = "raw both").toResponse()
@@ -168,7 +167,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
         val number = "abc"
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processError.name}", Verbs.POST, mapOf(), mapOf("text" to number)),
             response = Failure("$number is not a valid number").toResponse()
@@ -180,7 +179,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_get_list() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processInputListInt.name}", Verbs.POST, mapOf(), mapOf(Pair("items", listOf(1, 2, 3)))),
             response = Success("ok", msg = ",1,2,3").toResponse()
@@ -192,7 +191,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_get_list_via_conversion() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processInputListString.name}", Verbs.POST, mapOf(), mapOf(Pair("items", "1,2,3"))),
             response = Success("ok", msg = ",1,2,3").toResponse()
@@ -204,7 +203,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_get_map() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processInputMap.name}", Verbs.POST, mapOf(), mapOf(Pair("items", mapOf("a" to 1, "b" to 2)))),
             response = Success("ok", msg = ",a=1,b=2").toResponse()
@@ -216,7 +215,7 @@ class Api_002_Executor_Tests : ApiTestsBase() {
     fun can_get_map_via_conversion() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))))),
+            routes = routes(listOf(api(Sample_API_1_Core::class, Sample_API_1_Core(context)))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Core::processInputMap.name}", Verbs.POST, mapOf(), mapOf(Pair("items", "a=1,b=2"))),
             response = Success("ok", msg = ",a=1,b=2").toResponse()

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_MIddleware_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_MIddleware_Tests.kt
@@ -16,14 +16,10 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import kiit.apis.*
-import kiit.apis.routes.Api
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.results.Codes
 import kiit.results.Outcome
-import kiit.results.getOrElse
-import test.apis.samples.Sample_API_1_Core
 import test.setup.SampleMiddlewareApi
 
 /**
@@ -42,7 +38,7 @@ class Api_Middleware_Tests : ApiTestsBase() {
             "api_test" to apiMiddleware,
             "action_test" to actionMiddleware
         )
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleMiddlewareApi::class, api)))))
+        val routes = routes(listOf(api(SampleMiddlewareApi::class, api)))
         val apis = ApiServer(ctx, routes = routes, middleware = policies )
         val r1 = runBlocking { apis.executeAttempt("app", "SampleMiddleware", SampleMiddlewareApi::hi.name, Verb.Post, mapOf(), mapOf()) }
         val r2 = runBlocking { apis.executeAttempt("app", "SampleMiddleware", SampleMiddlewareApi::hello.name, Verb.Post, mapOf(), mapOf()) }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Naming_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Naming_Tests.kt
@@ -8,7 +8,6 @@ import kiit.apis.ApiServer
 import kiit.apis.Settings
 import kiit.apis.Verb
 import kiit.apis.Verbs
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.utils.naming.LowerHyphenNamer
@@ -24,7 +23,7 @@ class Api_Naming_Tests : ApiTestsBase() {
 
     @Test fun can_use_naming_convention_lowerHyphen() {
         val namer = LowerHyphenNamer()
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SamplePOKOApi::class, SamplePOKOApi())))), namer = namer)
+        val routes = routes(listOf(api(SamplePOKOApi::class, SamplePOKOApi())), namer = namer)
         val apis = ApiServer(ctx, routes, settings = Settings(naming = namer))
         Assert.assertNotNull( apis.get(Verbs.GET , "tests"   , "sample-poko", "get-time"    ))
         Assert.assertNull   ( apis.get(Verbs.GET , "tests"   , "SamplePOKO" , "getTime"     ))
@@ -45,7 +44,7 @@ class Api_Naming_Tests : ApiTestsBase() {
 
     @Test fun can_use_naming_convention_lowerUnderscore() {
         val namer = LowerUnderscoreNamer()
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleExtendedApi::class, SampleExtendedApi(), declared = false)))), namer = namer)
+        val routes = routes(listOf(api(SampleExtendedApi::class, SampleExtendedApi(), declared = false)), namer = namer)
         val apis = ApiServer(ctx, routes, settings = Settings(naming = namer))
         Assert.assertNotNull( apis.get(Verbs.GET , "tests"   , "sample_extended", "get_seconds" ))
         Assert.assertNotNull( apis.get(Verbs.GET , "tests"   , "sample_extended", "get_time"    ))

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Protocol_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Protocol_Tests.kt
@@ -14,7 +14,6 @@ package test.apis
 
 import org.junit.Test
 import kiit.apis.Verbs
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.requests.CommonRequest
@@ -42,7 +41,7 @@ class Api_Protocol_Tests : ApiTestsBase() {
     fun should_work_when_setup_as_protocol_CLI_request_is_CLI_via_parent() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))))),
+            routes = routes(listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Protocol::processParent.name}", Verbs.POST, mapOf(), mapOf(Pair("name", "abc"))),
             response = Success("ok", msg = "via parent:abc").toResponse()
@@ -54,7 +53,7 @@ class Api_Protocol_Tests : ApiTestsBase() {
     fun should_work_when_setup_as_protocol_CLI_request_is_CLI_explicit() {
         checkCall(
             protocol = Source.CLI,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))))),
+            routes = routes(listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Protocol::processCLI.name}", Verbs.POST, mapOf(), mapOf(Pair("name", "abc"))),
             response = Success("ok", msg = "via cli:abc").toResponse()
@@ -66,7 +65,7 @@ class Api_Protocol_Tests : ApiTestsBase() {
     fun should_work_when_setup_as_protocol_all_request_is_ALL_via_parent() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))))),
+            routes = routes(listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))),
             user = null,
             request = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Protocol::processParent.name}", Verbs.POST, mapOf(), mapOf(Pair("name", "abc"))),
             response = Success("ok", msg = "via parent:abc").toResponse()
@@ -77,7 +76,7 @@ class Api_Protocol_Tests : ApiTestsBase() {
     @Test fun should_work_when_setup_as_parent_protocol_CLI_and_request_is_CLI() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))))),
+            routes = routes(listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))),
             user     = null,
             request  = CommonRequest.path("$AREA.$NAME.${Sample_API_1_Protocol::processCLI.name}",  Verbs.POST, mapOf(), mapOf(Pair("name", "abc"))),
             response = Success("ok", msg = "via cli:abc").toResponse()
@@ -89,7 +88,7 @@ class Api_Protocol_Tests : ApiTestsBase() {
     fun should_fail_when_setup_as_protocol_web_request_is_CLI_explicit() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))))),
+            routes = routes(listOf(api(Sample_API_1_Protocol::class, Sample_API_1_Protocol()))),
             user = null,
             request = CommonRequest.api("$AREA", "$NAME", "${Sample_API_1_Protocol::processCLI.name}", Verbs.POST, mapOf(), mapOf(Pair("name", "abc"))),
             response = Failure(Err.of("expected source cli, but got api"), msg = "Errored").toResponse(),

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Restful_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Restful_Tests.kt
@@ -19,7 +19,6 @@ import org.junit.Test
 import kiit.apis.*
 import kiit.apis.routes.Api
 import kiit.apis.services.Restify
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.common.*
@@ -66,7 +65,7 @@ class Api_Restful_Tests : ApiTestsBase() {
 
     @Test
     fun can_get_by_id() {
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val apis = ApiServer(ctx, rewriter = Restify(), routes = routes)
         val r1 = runBlocking {
             apis.executeAttempt("tests", "SampleREST", "1", Verb.Get, mapOf(), mapOf())
@@ -82,7 +81,7 @@ class Api_Restful_Tests : ApiTestsBase() {
     @Test
     fun can_patch() {
 
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val apis = ApiServer(ctx, rewriter = Restify(), routes = routes)
         val r1 = runBlocking {
             apis.executeAttempt(
@@ -100,7 +99,7 @@ class Api_Restful_Tests : ApiTestsBase() {
     @Test
     fun can_delete_by_id() {
 
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val apis = ApiServer(ctx, rewriter = Restify(), routes = routes)
         val r1 = runBlocking {
             apis.executeAttempt("tests", "SampleREST", "1", Verb.Delete, mapOf(), mapOf())
@@ -115,7 +114,7 @@ class Api_Restful_Tests : ApiTestsBase() {
     @Test
     fun can_activate_by_id() {
 
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val apis = ApiServer(ctx, rewriter = Restify(), routes = routes)
         val r1 = runBlocking {
             apis.executeAttempt("tests", "SampleREST", "activateById", Verb.Post, mapOf(), mapOf("id" to 1))
@@ -129,7 +128,7 @@ class Api_Restful_Tests : ApiTestsBase() {
 
     @Test
     fun can_create() {
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val json = JSONObject()
         json.put("id", "0")
         json.put("title", "Indiana Jones")
@@ -160,7 +159,7 @@ class Api_Restful_Tests : ApiTestsBase() {
 
     @Test
     fun can_update() {
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val json = JSONObject()
         json.put("id", "1")
         json.put("title", "Indiana Jones")
@@ -197,14 +196,14 @@ class Api_Restful_Tests : ApiTestsBase() {
         callback: (Result<*, *>) -> Unit
     ) {
 
-        val routes1 = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))))
+        val routes1 = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())))
         val apis = ApiServer(ctx, rewriter = Restify(), routes = routes1)
         val r1 = runBlocking {
             apis.executeAttempt("tests", "SampleREST", action, verb, mapOf(), args)
         }
         callback(r1)
 
-        val routes2 = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleRESTApi::class, SampleRESTApi())))), namer)
+        val routes2 = routes(listOf(api(SampleRESTApi::class, SampleRESTApi())), namer)
         val api2 = ApiServer(ctx, rewriter = Restify(), routes = routes2, settings = kiit.apis.Settings(naming = namer))
         val name = namer?.rename("SampleREST") ?: "SampleREST"
         val act = namer?.rename(action) ?: action

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Security_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Security_Tests.kt
@@ -13,10 +13,7 @@ about: A Kotlin utility library, tool-kit and server backend.
 package test.apis
 
 import org.junit.Test
-import kiit.apis.routes.Api
-import kiit.apis.SetupType
 import kiit.apis.Verbs
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.common.info.Credentials
@@ -26,7 +23,6 @@ import kiit.requests.toResponse
 import kiit.results.Success
 import kiit.results.builders.Notices
 import kiit.results.builders.Outcomes
-import test.apis.samples.Sample_API_1_Core
 import test.apis.samples.Sample_API_2_Roles
 
 /**
@@ -41,7 +37,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_should_work_when_role_is_any() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesAny", Verbs.POST, mapOf(), mapOf(
@@ -54,7 +50,7 @@ class Api_Security_Tests : ApiTestsBase() {
 
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "qa"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesAny", Verbs.POST, mapOf(), mapOf(
@@ -67,7 +63,7 @@ class Api_Security_Tests : ApiTestsBase() {
 
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = ""),
             request = CommonRequest.path(
                 "app.rolesTest.rolesAny", Verbs.POST, mapOf(), mapOf(
@@ -84,7 +80,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_should_fail_for_any_role_any_with_no_user() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = null,
             request = CommonRequest.path(
                 "app.rolesTest.rolesAny", Verbs.POST, mapOf(), mapOf(
@@ -101,7 +97,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_should_work_for_a_specific_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesSpecific", Verbs.POST, mapOf(), mapOf(
@@ -118,7 +114,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_should_fail_for_a_specific_role_when_user_has_a_different_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "ops"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesSpecific", Verbs.POST, mapOf(), mapOf(
@@ -135,7 +131,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_should_work_for_a_specific_role_when_referring_to_its_parent_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "admin"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesParent", Verbs.POST, mapOf(), mapOf(
@@ -152,7 +148,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_should_fail_for_a_specific_role_when_referring_to_its_parent_role_when_user_has_a_different_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesParent", Verbs.POST, mapOf(), mapOf(
@@ -170,7 +166,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_by_key_should_work_when_role_is_any() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesAny", Verbs.POST, mapOf(
@@ -189,7 +185,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_by_key_should_fail_for_any_role_with_no_user() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = null,
             request = CommonRequest.path(
                 "app.rolesTest.rolesAny", Verbs.POST, mapOf(), mapOf(
@@ -206,7 +202,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_by_key_should_work_for_a_specific_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesSpecific", Verbs.POST, mapOf(
@@ -225,7 +221,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_by_key_should_fail_for_a_specific_role_when_user_has_a_different_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "qa"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesSpecific", Verbs.POST, mapOf(
@@ -244,7 +240,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_by_key_should_work_for_a_specific_role_when_referring_to_its_parent_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "admin"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesParent", Verbs.POST, mapOf(
@@ -263,7 +259,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun roles_by_key_should_fail_for_a_specific_role_when_referring_to_its_parent_role_when_user_has_a_different_role() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.rolesParent", Verbs.POST, mapOf(
@@ -282,7 +278,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun should_use_action_auth_as_override() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.authOverride", Verbs.POST, mapOf(
@@ -301,7 +297,7 @@ class Api_Security_Tests : ApiTestsBase() {
     fun should_use_action_auth_as_override_fails_with_bad_key() {
         checkCall(
             protocol = Source.All,
-            routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))))),
+            routes = routes(listOf(api(Sample_API_2_Roles::class, Sample_API_2_Roles()))),
             user = Credentials(name = "kishore", roles = "dev"),
             request = CommonRequest.path(
                 "app.rolesTest.authOverride", Verbs.POST, mapOf(

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Validation_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/apis/Api_Validation_Tests.kt
@@ -17,14 +17,10 @@ import org.junit.Assert
 import org.junit.Test
 import org.threeten.bp.ZoneId
 import kiit.apis.*
-import kiit.apis.routes.Api
-import kiit.apis.SetupType
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.common.DateTimes
 import kiit.results.*
-import test.apis.samples.Sample_API_1_Core
 import test.apis.samples.Sample_API_1_Validation
 
 /**
@@ -40,7 +36,7 @@ class Api_Validation_Tests : ApiTestsBase() {
 
     @Test
     fun can_fail_with_missing_args() {
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Validation::class, Sample_API_1_Validation())))))
+        val routes = routes(listOf(api(Sample_API_1_Validation::class, Sample_API_1_Validation())))
         val apis = ApiServer(ctx, routes = routes)
         val r1 = runBlocking {
             apis.executeAttempt("tests", "validation", Sample_API_1_Validation::processInputs.name, Verb.Post, mapOf(), mapOf())
@@ -61,7 +57,7 @@ class Api_Validation_Tests : ApiTestsBase() {
 
     @Test
     fun can_fail_with_conversion() {
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(Sample_API_1_Validation::class, Sample_API_1_Validation())))))
+        val routes = routes(listOf(api(Sample_API_1_Validation::class, Sample_API_1_Validation())))
         val apis = ApiServer(ctx, routes = routes)
         val r1 = runBlocking {
             apis.executeAttempt("tests", "validation", Sample_API_1_Validation::processInputs.name, Verb.Post, mapOf(), mapOf(

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/ShellTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/cli/ShellTests.kt
@@ -13,12 +13,12 @@
 
 package slate.test
 
+import kiit.apis.setup.ApiSetup
+import kiit.apis.setup.api
+import kiit.apis.setup.routes
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
-import kiit.apis.routes.Api
-import kiit.apis.SetupType
-import kiit.apis.routes.VersionAreas
 import kiit.apis.support.Authenticator
 import kiit.cli.CliRequest
 import kiit.cli.CliResponse
@@ -117,10 +117,10 @@ class ShellTests  {
             Credentials("1", "kishore", "kishore@abc.com", apiKeys.last().key, "test", "ny")
 
     // 2. Register the apis using default textType ( uses permissions in annotations on class )
-    val apis = listOf<VersionAreas>(
-//            Api(InfoApi(ctx), setup = SetupType.Annotated, declaredOnly = true, roles = listOf("qa")),
-//            Api(VersionApi(ctx), setup = SetupType.Annotated, declaredOnly = true, roles = listOf("qa"))
-    )
+    val apis = routes(listOf<ApiSetup>(
+        api(InfoApi::class, InfoApi(ctx)),
+        api(VersionApi::class, VersionApi(ctx))
+    ))
 
     // 3. Build up the cli services that handles all the command line features.
     // And setup the api container to hold all the apis.

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/jobs/Worker_Api_Tests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/jobs/Worker_Api_Tests.kt
@@ -1,15 +1,12 @@
 package test.jobs
 
 import kiit.apis.*
-import kiit.apis.Middleware
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
 import org.threeten.bp.ZoneId
 
-import kiit.apis.routes.Api
 import kiit.apis.core.Reqs
-import kiit.apis.setup.GlobalVersion
 import kiit.apis.setup.api
 import kiit.apis.setup.routes
 import kiit.common.*
@@ -35,7 +32,7 @@ class Worker_Api_Tests : TestSupport {
     fun buildContainer(): ApiServer {
         val ctx = AppContext.simple(app,"queues")
         val api = SampleTypes2Api()
-        val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleTypes2Api::class, api)))))
+        val routes = routes(listOf(api(SampleTypes2Api::class, api)))
         val apis = ApiServer(ctx, routes = routes)
         return apis
     }
@@ -58,7 +55,7 @@ class Worker_Api_Tests : TestSupport {
             val policies = listOf("queued" to policy)
 
             // 4. container
-            val routes = routes(versions = listOf(GlobalVersion("0", listOf(api(SampleWorkerAPI::class, api)))))
+            val routes = routes(listOf(api(SampleWorkerAPI::class, api)))
             val apis = ApiServer(ctx, routes = routes, middleware = policies)
 
             // 5. send method call to queue

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/SampleApi.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/SampleApi.kt
@@ -39,7 +39,30 @@ class SampleApi1(val context: Context) {
     @Action(desc = "test simple action with inputs")
     @Documented(path = "docs/apis", key = "actions.tests.repeat")
     fun repeat(word: String, count:Int): String {
-        return (0 until count).map { word }.joinToString(" ")
+        return (0 until count).joinToString(" ") { word }
+    }
+}
+
+
+
+@Api(area = "app", name = "sample1", version = "v1", desc = "sample to test features of Slate Kit APIs")
+class SampleApi1V1(val context: Context) {
+
+    @Action(desc = "test simple action with inputs")
+    @Documented(path = "docs/apis", key = "actions.tests.repeat")
+    fun repeat(word: String, count:Int): String {
+        return (0 until count).joinToString(" ") { word }
+    }
+}
+
+
+@Api(area = "app", name = "sample2", version = "v2", desc = "sample to test features of Slate Kit APIs")
+class SampleApi2V2(val context: Context) {
+
+    @Action(desc = "test simple action with inputs")
+    @Documented(path = "docs/apis", key = "actions.tests.repeat")
+    fun repeat(word: String, count:Int): String {
+        return (0 until count).joinToString(" ") { word }
     }
 }
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/SampleApi.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/SampleApi.kt
@@ -53,6 +53,12 @@ class SampleApi1V1(val context: Context) {
     fun repeat(word: String, count:Int): String {
         return (0 until count).joinToString(" ") { word }
     }
+
+    @Action(desc = "test simple action with inputs")
+    @Documented(path = "docs/apis", key = "actions.tests.repeat")
+    fun loop(word: String, count:Int): String {
+        return (0 until count).joinToString(" ") { word }
+    }
 }
 
 
@@ -62,6 +68,12 @@ class SampleApi2V2(val context: Context) {
     @Action(desc = "test simple action with inputs")
     @Documented(path = "docs/apis", key = "actions.tests.repeat")
     fun repeat(word: String, count:Int): String {
+        return (0 until count).joinToString(" ") { word }
+    }
+
+    @Action(desc = "test simple action with inputs")
+    @Documented(path = "docs/apis", key = "actions.tests.repeat")
+    fun loop(word: String, count:Int): String {
         return (0 until count).joinToString(" ") { word }
     }
 }

--- a/src/services/apis/src/main/kotlin/kiit/apis/ApiServer.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/ApiServer.kt
@@ -20,7 +20,6 @@ import kiit.requests.CommonRequest
 import kiit.requests.Request
 import kiit.requests.Response
 import kiit.context.Context
-import kiit.meta.*
 import kiit.serialization.deserializer.Deserializer
 import kiit.results.*
 import kiit.results.builders.Outcomes
@@ -50,7 +49,7 @@ open class ApiServer(
      * Load all the routes from the APIs supplied.
      * The API setup can be either annotation based or public methods on the Class
      */
-    private val router = Router(routes, settings.naming)
+    private val router = DefaultRouter(routes, settings.naming)
 
     /**
      * Decoder for converting Request Body JSON to method parameter values.
@@ -122,7 +121,7 @@ open class ApiServer(
      * @return
      */
     fun get(verb:String, area: String, name: String, action: String, globalVersion:String = ApiConstants.zero, version:String? = null): Route? {
-        val action = router.action(verb, area, name, action, globalVersion, version)
+        val action = router.getAction(verb, area, name, action, globalVersion, version)
         return action
     }
 

--- a/src/services/apis/src/main/kotlin/kiit/apis/ApiServer.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/ApiServer.kt
@@ -36,7 +36,7 @@ import kotlin.reflect.KClass
  */
 open class ApiServer(
     val ctx: Context,
-    val routes: List<VersionAreas>,
+    val routes: Areas,
     val rewriter: Rewriter? = null,
     middleware: List<Pair<String,Middleware>> = listOf(),
     val auth: Auth? = null,
@@ -120,8 +120,8 @@ open class ApiServer(
      * @param action : e.g. "register"
      * @return
      */
-    fun get(verb:String, area: String, name: String, action: String, globalVersion:String = ApiConstants.zero, version:String? = null): Route? {
-        val action = router.getAction(verb, area, name, action, globalVersion, version)
+    fun get(verb:String, area: String, name: String, action: String, apiVersion:String = ApiConstants.zero, actionVersion:String? = null): Route? {
+        val action = router.getAction(verb, area, name, apiVersion, action, actionVersion ?: ApiConstants.zero)
         return action
     }
 
@@ -239,8 +239,9 @@ open class ApiServer(
 
         const val VERSION_HEADER_KEY = "x-api-version"
 
+
         @JvmStatic
-        fun of(ctx: Context, routes: List<VersionAreas>, auth: Auth? = null, source: Source? = null): ApiServer {
+        fun of(ctx: Context, routes: Areas, auth: Auth? = null, source: Source? = null): ApiServer {
             val server = ApiServer(ctx, routes, null, listOf(), auth, null, listOf(), Settings(source ?: Source.API))
             return server
         }

--- a/src/services/apis/src/main/kotlin/kiit/apis/executor/Executor.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/executor/Executor.kt
@@ -58,16 +58,16 @@ class Executor(
      * 3. action execute: Finally, the action method execution is run.
      */
     private suspend fun executeFlow(req:ApiRequest, op:suspend (ApiRequest) -> Outcome<ApiResult>): Outcome<ApiResult> {
-        val path = req.target!!.path
+        val route = req.target!!
 
         // Level: Action ( this executes last )
-        val actions = path.action.policies.map { middlewares[it] }.filterNotNull()
+        val actions = route.action.policies.map { middlewares[it] }.filterNotNull()
         val actionFlow: suspend (ApiRequest) -> Outcome<ApiResult> = { r ->
             Middleware.process(r, 0, actions, op)
         }
 
         // Level: API
-        val global = path.api.policies.map { middlewares[it] }.filterNotNull()
+        val global = route.api.policies.map { middlewares[it] }.filterNotNull()
         val result = Middleware.process(req, 0, global, actionFlow)
         return result
     }

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Area.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Area.kt
@@ -21,5 +21,5 @@ import kiit.apis.ApiConstants
  * From the example above, this represents the area "accounts" and it's mapped list of apis/classes
  */
 class Area(val name: String, val version:String = ApiConstants.zero) {
-    val fullname:String = "$version.$name"
+    val fullName:String = "$version.$name"
 }

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Lookup.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Lookup.kt
@@ -14,25 +14,25 @@ interface Lookup<T> {
 /**
  * Lookup for all apis on an Area
  */
-class Areas(override val items: List<Apis>) : Lookup<Apis> {
+class Areas(override val items: List<AreaApis>) : Lookup<AreaApis> {
     override val name: String = "root"
-    override val map: Map<String, Apis> = items.associateBy { it.name }
+    override val map: Map<String, AreaApis> = items.associateBy { it.name }
 }
 
 
 /**
  * Lookup for all apis on an Area
  */
-class Apis(val area:Area, override val items: List<Actions>) : Lookup<Actions> {
+class AreaApis(val area:Area, override val items: List<ApiActions>) : Lookup<ApiActions> {
     override val name: String = area.name
-    override val map: Map<String, Actions> = items.associateBy { it.name }
+    override val map: Map<String, ApiActions> = items.associateBy { it.name }
 }
 
 
 /**
  * Look up for all actions on an API
  */
-class Actions(val api:Api, override val items: List<Route>) : Lookup<Route> {
+class ApiActions(val api:Api, override val items: List<Route>) : Lookup<Route> {
     override val name: String = "${api.version}:${api.name}"
     override val map: Map<String, Route> = toMap(items)
 

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Lookup.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Lookup.kt
@@ -10,10 +10,29 @@ interface Lookup<T> {
     fun get(key:String):T? = map[key]
 }
 
+
+/**
+ * Lookup for all apis on an Area
+ */
+class Areas(override val items: List<Apis>) : Lookup<Apis> {
+    override val name: String = "root"
+    override val map: Map<String, Apis> = items.associateBy { it.name }
+}
+
+
+/**
+ * Lookup for all apis on an Area
+ */
+class Apis(val area:Area, override val items: List<Actions>) : Lookup<Actions> {
+    override val name: String = area.name
+    override val map: Map<String, Actions> = items.associateBy { it.name }
+}
+
+
 /**
  * Look up for all actions on an API
  */
-class ApiActions(val api:Api, override val items: List<Route>) : Lookup<Route> {
+class Actions(val api:Api, override val items: List<Route>) : Lookup<Route> {
     override val name: String = "${api.version}:${api.name}"
     override val map: Map<String, Route> = toMap(items)
 
@@ -21,7 +40,7 @@ class ApiActions(val api:Api, override val items: List<Route>) : Lookup<Route> {
         fun toMap(mappings: List<Route>): Map<String, Route> {
             val pairs = mappings.map {
                 // key = "{VERB}.{VERSION}.{NAME}"
-                val action = it.path.action
+                val action = it.action
                 val name = "${action.verb.name}.${action.version}:${action.name}"
                 name to it
             }
@@ -32,18 +51,9 @@ class ApiActions(val api:Api, override val items: List<Route>) : Lookup<Route> {
 
 
 /**
- * Lookup for all apis on an Area
- */
-class AreaApis(val area:Area, override val items: List<ApiActions>) : Lookup<ApiActions> {
-    override val name: String = area.name
-    override val map: Map<String, ApiActions> = items.map { Pair(it.name, it) }.toMap()
-}
-
-
-/**
  * Lookup for all areas in a global version
  */
-class VersionAreas(val version:String, override val items: List<AreaApis>) : Lookup<AreaApis> {
+class VersionAreas(val version:String, override val items: List<Apis>) : Lookup<Apis> {
     override val name: String = version
-    override val map: Map<String, AreaApis> = items.map { Pair(it.name, it) }.toMap()
+    override val map: Map<String, Apis> = items.associateBy { it.name }
 }

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Lookup.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Lookup.kt
@@ -48,12 +48,3 @@ class Actions(val api:Api, override val items: List<Route>) : Lookup<Route> {
         }
     }
 }
-
-
-/**
- * Lookup for all areas in a global version
- */
-class VersionAreas(val version:String, override val items: List<Apis>) : Lookup<Apis> {
-    override val name: String = version
-    override val map: Map<String, Apis> = items.associateBy { it.name }
-}

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Route.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Route.kt
@@ -1,7 +1,8 @@
 package kiit.apis.routes
 
 /**
- * Represents the 3 part routing convention in Kiit API actions.
+ * Represents a mapping of the path and handle to execute action in the path
+ * A path is the 3 part routing convention in Kiit API actions.
  * Example:
  * 1. format: {area}/{api}/{action}
  * 2. sample: content/blog/create
@@ -9,15 +10,9 @@ package kiit.apis.routes
  * @param area   : 1st level logical group that the api belongs to
  * @param api    : 2nd level logical group of related actions/endpoints
  * @param action : 3rd level executable portion that maps to a method
- */
-data class Path(val area:Area, val api:Api, val action: Action) {
-    val name:String = "${area.name}/${api.name}/${action.name}"
-}
-
-
-/**
- * Represents a mapping of the path and handle to execute action in the path
  * Example:
  * content/blog/create -> MethodExecutor( BlogApi::create method )
  */
-data class Route(val path: Path, val handler: RouteHandler)
+data class Route(val area:Area, val api:Api, val action: Action, val handler: RouteHandler) {
+    val path:String = "${area.name}/${api.name}/${action.name}"
+}

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
@@ -4,6 +4,31 @@ import kiit.apis.ApiConstants
 import kiit.utils.naming.Namer
 
 /**
+ * Interface for the router.
+ * This provides support for versioning at
+ * 1. Area/Global  versioning : e.g. /v1/{area}/{api} v1 of area ( with many apis )
+ * 2. API/Resource versioning : e.g. /{area}/v1/{api} v1 of api
+ * 3. Action level versioning : e.g. /{area}/v1/{api} v2 of action ( via a header )
+ */
+interface Router {
+    fun containsArea(area: String): Boolean
+
+    fun containsApi(area: String, api: String, version:String? = null): Boolean {
+        return containsApi(area, api, version ?: ApiConstants.zero)
+    }
+
+    fun containsApi(area: String, api: String, version:String): Boolean
+
+    fun containsAction(verb: String, area: String, api: String, action: String): Boolean {
+        return containsAction(verb, area, api, ApiConstants.zero, action, ApiConstants.zero)
+    }
+    fun containsAction(verb: String, area: String, api: String, apiVersion:String, action: String, actionVersion:String): Boolean
+//    fun getArea(area: String, globalVersion: String = ApiConstants.zero): Area
+//    fun getApi(area: String, globalVersion: String = ApiConstants.zero, api: String, version: String? = null): ApiActions?
+//    fun getAction(verb:String, area: String, globalVersion: String = ApiConstants.zero, api: String, action: String, version: String? = null): Route?
+}
+
+/**
  * The top most level qualifier in the Universal Routing Structure
  * Essentially the root of the Routing tree
  * e.g.
@@ -11,22 +36,22 @@ import kiit.utils.naming.Namer
  * Format :  {area}.{api}.{action}
  * Routes :
  *          { Area A }
- *              - { API X - v1 }
+ *              - { v1 / API 1 }
  *                  - { Action a - v1 }
  *                  - { Action a - v2 }
  *                  - { Action b - v1 }
  *
  *         { Area B }
- *              - { API Y - v1 }
+ *              - { v1 / API 2 }
  *                  - { Action a - v1 }
  *                  - { Action a - v2 }
  *                  - { Action b - v1 }
 */
-data class Router(
+data class DefaultRouter(
     val versions: List<VersionAreas>,
     val namer: Namer? = null,
     val onInstanceCreated: ((Any?) -> Unit)? = null
-) {
+) : Router {
 
     init {
         onInstanceCreated?.let {
@@ -35,27 +60,11 @@ data class Router(
     }
 
     /**
-     * gets the api info associated with the request
-     * @param cmd
-     * @return
-     */
-    fun check(verb:String, path: String): Boolean {
-        val parts = path.split('.')
-        return when (parts.size) {
-            0 -> false
-            1 -> containsArea(parts[0]) || containsArea("", parts[0])
-            2 -> containsApi(parts[0], parts[1]) || containsApi("", parts[0], parts[1])
-            3 -> containsAction(verb, parts[0], parts[1], parts[2])
-            else -> false
-        }
-    }
-
-    /**
      * Whether there is an area w/ the supplied name.
      */
-    fun containsArea(area: String, globalVersion:String = ApiConstants.zero): Boolean {
+    override fun containsArea(area: String): Boolean {
         if (area.isEmpty()) return false
-        val match = versions.firstOrNull { it.version == globalVersion }
+        val match = versions.firstOrNull { it.version == ApiConstants.zero }
         return match?.let { it.get(area) != null } ?: false
     }
 
@@ -63,30 +72,28 @@ data class Router(
      * Whether there is an api in the area supplied
      * @param area    : The name of the area e.g. "accounts"
      * @param api     : The name of the api  e.g. "signup"
-     * @param globalVersion : The global version of entire api set to check for
      * @param version : The version to check for e.g. "1.1" indicates api:version=1, action:version = 1
      */
-    fun containsApi(area: String, api: String, globalVersion: String = ApiConstants.zero, version:String? = null): Boolean {
-        return api(area, api, globalVersion, version) != null
+    override fun containsApi(area: String, api: String, version:String): Boolean {
+        return getApi(area, api, version) != null
     }
 
     /**
      * Whether there is an action in the area/api supplied
      * @param area    : The name of the area e.g. "accounts"
      * @param api     : The name of the api  e.g. "signup"
+     * @param apiVersion : The global version of entire api set to check for
      * @param action  : The name of the action  e.g. "login"
-     * @param globalVersion : The global version of entire api set to check for
-     * @param version : The version to check for e.g. "1.1" indicates api:version=1, action:version = 1
+     * @param actionVersion : The version to check for e.g. "1.1" indicates api:version=1, action:version = 1
      */
-    fun containsAction(verb: String, area: String, api: String, action: String, globalVersion: String = ApiConstants.zero, version:String? = null): Boolean {
-        return action(verb, area, api, action, globalVersion, version) != null
+    override fun containsAction(verb: String, area: String, api: String, apiVersion:String, action: String, actionVersion:String): Boolean {
+        return getAction(verb, area, api, apiVersion, action, actionVersion) != null
     }
 
     /**
      * Gets the API model associated with the area.name
      */
-    fun api(area: String, api: String, globalVersion: String = "0", version: String? = null): ApiActions? {
-        if (globalVersion.isEmpty()) return null
+    fun getApi(area: String, api: String, version: String? = null): Actions? {
         if (area.isEmpty()) return null
         if (api.isEmpty()) return null
         val info = when (version) {
@@ -99,7 +106,7 @@ data class Router(
             }
         }
 
-        val versionLookup = versions.firstOrNull { it.version == globalVersion } ?: return null
+        val versionLookup = versions.firstOrNull { it.version == ApiConstants.zero } ?: return null
         val areaLookup = versionLookup.get(area) ?: return null
         val actionLookup = areaLookup.get(info.first)
         return actionLookup
@@ -109,42 +116,41 @@ data class Router(
      * gets the mapped method associated with the api action.
      * @param area
      * @param name
-     * @param action
+     * @param getAction
      * @return
      */
-    fun action(verb:String, area: String, api: String, action: String, globalVersion: String = ApiConstants.zero, version: String? = null): Route? {
-        val mapping = actionInternal(verb, area, api, action, globalVersion, version)
+    fun getAction(verb:String, area: String, api: String, apiVersion: String, action: String, actionVersion:String): Route? {
+        val mapping = actionInternal(verb, area, api,  apiVersion, action, actionVersion)
         return when {
             mapping != null && (mapping.handler is MethodExecutor) -> mapping
             mapping != null && (mapping.handler is RouteForwarder) -> {
                 val rf = mapping.handler as RouteForwarder
-                val redirect = actionInternal(rf.verb.name, rf.area.name, rf.api.name, rf.action.name, rf.globalVersion, null)
+                val redirect = actionInternal(rf.verb.name, rf.area.name, rf.api.name,  apiVersion,rf.action.name, actionVersion)
                 redirect
             }
             else -> mapping
         }
     }
 
-    private fun actionInternal(verb:String, area: String, api: String, action: String, globalVersion: String = ApiConstants.zero, version: String?): Route? {
-        if (globalVersion.isEmpty()) return null
+    private fun actionInternal(verb:String, area: String, api: String, apiVersion: String, action: String, actionVersion: String): Route? {
         if (area.isEmpty()) return null
         if (api.isEmpty()) return null
-        val info = when (version) {
+        val info = when (actionVersion) {
             null -> Pair(ApiConstants.zero, ApiConstants.zero)
             else -> {
-                val parts = version.split(".")
+                val parts = apiVersion.split(".")
                 val apiVersion = parts[0]
                 val actionVersion = parts[1]
                 Pair(apiVersion, actionVersion)
             }
         }
-        val apiLookup = api(area, api, globalVersion, version)
+        val apiLookup = getApi(area, api, apiVersion)
         val actionName = "${verb}.${info.second}:${action}"
         val mapping = apiLookup?.get(actionName)
         return mapping
     }
 
-    fun visitApis(visitor: (Area, ApiActions) -> Unit) {
+    fun visitApis(visitor: (Area, Actions) -> Unit) {
 
 //        // 1. Each top level area in the system
 //        // e.g. {area}/{api}/{action}
@@ -169,10 +175,5 @@ data class Router(
 //                }
 //            }
 //        }
-    }
-
-
-    companion object {
-
     }
 }

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
@@ -123,17 +123,8 @@ data class DefaultRouter(
     private fun actionInternal(verb:String, area: String, api: String, apiVersion: String, action: String, actionVersion: String): Route? {
         if (area.isEmpty()) return null
         if (api.isEmpty()) return null
-        val info = when (actionVersion) {
-            null -> Pair(ApiConstants.zero, ApiConstants.zero)
-            else -> {
-                val parts = apiVersion.split(".")
-                val apiVersion = parts[0]
-                val actionVersion = parts[1]
-                Pair(apiVersion, actionVersion)
-            }
-        }
         val apiLookup = getApi(area, api, apiVersion)
-        val actionName = "${verb}.${info.second}:${action}"
+        val actionName = "${verb}.${actionVersion}:${action}"
         val mapping = apiLookup?.get(actionName)
         return mapping
     }

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
@@ -48,7 +48,7 @@ interface Router {
  *                  - { Action b - v1 }
 */
 data class DefaultRouter(
-    val versions: List<VersionAreas>,
+    val areas: Areas,
     val namer: Namer? = null,
     val onInstanceCreated: ((Any?) -> Unit)? = null
 ) : Router {
@@ -64,8 +64,7 @@ data class DefaultRouter(
      */
     override fun containsArea(area: String): Boolean {
         if (area.isEmpty()) return false
-        val match = versions.firstOrNull { it.version == ApiConstants.zero }
-        return match?.let { it.get(area) != null } ?: false
+        return areas.contains(area)
     }
 
     /**
@@ -106,8 +105,7 @@ data class DefaultRouter(
             }
         }
 
-        val versionLookup = versions.firstOrNull { it.version == ApiConstants.zero } ?: return null
-        val areaLookup = versionLookup.get(area) ?: return null
+        val areaLookup = areas.get(area) ?: return null
         val actionLookup = areaLookup.get(info.first)
         return actionLookup
     }

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
@@ -88,22 +88,16 @@ data class DefaultRouter(
     /**
      * Gets the API model associated with the area.name
      */
-    fun getApi(area: String, api: String, version: String? = null): Actions? {
+    fun getApi(area: String, api: String, version: String? = null): ApiActions? {
         if (area.isEmpty()) return null
         if (api.isEmpty()) return null
-        val info = when (version) {
-            null -> Pair("0:${api}", ApiConstants.zero)
-            else -> {
-                val parts = version.split(".")
-                val apiVersion = parts[0]
-                val actionVersion = parts[1]
-                Pair("${apiVersion}:${api}", "${actionVersion}:")
-            }
+        val apis = areas.get(area) ?: return null
+        val name = when(version) {
+            null -> "0:${api}"
+            else -> "$version:${api}"
         }
-
-        val areaLookup = areas.get(area) ?: return null
-        val actionLookup = areaLookup.get(info.first)
-        return actionLookup
+        val api = apis.get(name)
+        return api
     }
 
     /**
@@ -144,7 +138,7 @@ data class DefaultRouter(
         return mapping
     }
 
-    fun visitApis(visitor: (Area, Actions) -> Unit) {
+    fun visitApis(visitor: (Area, ApiActions) -> Unit) {
 
 //        // 1. Each top level area in the system
 //        // e.g. {area}/{api}/{action}

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Router.kt
@@ -13,11 +13,7 @@ import kiit.utils.naming.Namer
 interface Router {
     fun containsArea(area: String): Boolean
 
-    fun containsApi(area: String, api: String, version:String? = null): Boolean {
-        return containsApi(area, api, version ?: ApiConstants.zero)
-    }
-
-    fun containsApi(area: String, api: String, version:String): Boolean
+    fun containsApi(area: String, api: String, version:String?): Boolean
 
     fun containsAction(verb: String, area: String, api: String, action: String): Boolean {
         return containsAction(verb, area, api, ApiConstants.zero, action, ApiConstants.zero)
@@ -73,7 +69,7 @@ data class DefaultRouter(
      * @param api     : The name of the api  e.g. "signup"
      * @param version : The version to check for e.g. "1.1" indicates api:version=1, action:version = 1
      */
-    override fun containsApi(area: String, api: String, version:String): Boolean {
+    override fun containsApi(area: String, api: String, version:String?): Boolean {
         return getApi(area, api, version) != null
     }
 

--- a/src/services/apis/src/main/kotlin/kiit/apis/routes/Routes.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/routes/Routes.kt
@@ -1,0 +1,7 @@
+package kiit.apis.routes
+
+/**
+ * Collection of all the routes, broken out by areas, apis and versions
+ */
+class Routes {
+}

--- a/src/services/apis/src/main/kotlin/kiit/apis/rules/AuthRule.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/rules/AuthRule.kt
@@ -8,9 +8,9 @@ import kiit.results.builders.Outcomes
 object AuthRule : Rule {
     override fun validate(req:ApiRequest): Outcome<Boolean> {
         val target = req.target!!
-        val api = target.path.api
+        val api = target.api
         val noAuth = req.auth == null //|| api.auth.isNullOrEmpty()
-        val actionRoles = target.path.action.roles.orElse(api.roles)
+        val actionRoles = target.action.roles.orElse(api.roles)
         val isAuthed = actionRoles.isAuthed
 
         // CASE 1: No auth for action
@@ -23,7 +23,7 @@ object AuthRule : Rule {
         }
         // CASE 3: Proceed to authorize
         else {
-            req.auth?.check(req.request, target.path.action.auth, actionRoles)
+            req.auth?.check(req.request, target.action.auth, actionRoles)
                 ?: Outcomes.denied("Auth not configured")
         }
         return Outcomes.invalid()

--- a/src/services/apis/src/main/kotlin/kiit/apis/rules/ProtoRule.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/rules/ProtoRule.kt
@@ -15,8 +15,8 @@ object ProtoRule : Rule {
         // Ensure verb is correct get/post
         val request = req.request
         val target = req.target!!
-        val actionVerb = target.path.action.verb.orElse(target.path.api.verb)
-        val actionProtocols = target.path.action.sources.orElse(target.path.api.sources)
+        val actionVerb = target.action.verb.orElse(target.api.verb)
+        val actionProtocols = target.action.sources.orElse(target.api.sources)
         val hasCli = actionProtocols.hasCLI()
         val hasApi = actionProtocols.hasAPI()
 

--- a/src/services/apis/src/main/kotlin/kiit/apis/services/Help.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/services/Help.kt
@@ -13,7 +13,7 @@ package kiit.apis.services
 
 import kiit.apis.ApiServer
 import kiit.apis.core.Part
-import kiit.apis.routes.Router
+import kiit.apis.routes.DefaultRouter
 import kiit.apis.tools.docs.Doc
 import kiit.apis.tools.docs.DocUtils
 import kiit.common.types.Content
@@ -23,7 +23,7 @@ import kiit.results.*
 import kiit.results.builders.Outcomes
 
 
-open class Help(val host: ApiServer, val routes: Router, val docKey: String?, val docBuilder: () -> Doc) {
+open class Help(val host: ApiServer, val routes: DefaultRouter, val docKey: String?, val docBuilder: () -> Doc) {
 
     fun process(req: Request): Outcome<Content> {
         val result = DocUtils.isHelp(req)

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/ConfigLoader.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/ConfigLoader.kt
@@ -180,7 +180,7 @@ class ConfigLoader(val cls: KClass<*>, val instance: Any) {
         val parts = target.split("/")
         val version = json.get("version") as String
         val verb = Verb.parse(json.get("verb") as String)
-        return RouteForwarder(version, verb, Area(parts[0]), Versioned(parts[1]), Versioned(parts[2]))
+        return RouteForwarder("0", verb, Area(parts[0]), Versioned(parts[1], version), Versioned(parts[2]))
     }
 
 

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/ConfigLoader.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/ConfigLoader.kt
@@ -185,11 +185,8 @@ class ConfigLoader(val cls: KClass<*>, val instance: Any) {
 
 
     private fun buildRoute(area: Area, api: Api, action: Action, handler: RouteHandler): Route {
-        // area/api/action objects ( with version info )
-        val path = Path(area, api, action)
-
-        // Final mapping of route -> handler
-        return Route(path, handler)
+        // Final mapping of route(area, api, action) -> handler
+        return Route(area, api, action, handler)
     }
 
     fun toList(items:JSONArray?) : List<String> {

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/ConfigLoader.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/ConfigLoader.kt
@@ -178,7 +178,7 @@ class ConfigLoader(val cls: KClass<*>, val instance: Any) {
     private fun buildRedirect(json: JSONObject, methods: Map<String, KCallable<*>>): RouteForwarder {
         val target = json.get("target") as String
         val parts = target.split("/")
-        val version = json.get("globalVersion") as String
+        val version = json.get("version") as String
         val verb = Verb.parse(json.get("verb") as String)
         return RouteForwarder(version, verb, Area(parts[0]), Versioned(parts[1]), Versioned(parts[2]))
     }

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/Loader.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/Loader.kt
@@ -10,7 +10,8 @@ import org.json.simple.JSONObject
 import org.json.simple.parser.JSONParser
 
 class Loader(val namer: Namer?)  {
-    fun routes(version:String, setup:List<ApiSetup>) : VersionAreas {
+
+    fun routes(setup:List<ApiSetup>) : Areas {
         val actions = setup.map {
             when(it.setup) {
                 SetupType.Annotated -> code(it.klass, it.singleton!!, it.declared)
@@ -19,8 +20,7 @@ class Loader(val namer: Namer?)  {
         }
         val areaNames = actions.map { Area(it.api.area) }.distinctBy { it.fullName }
         val apis = areaNames.map { area -> Apis(area, actions.filter { it.api.area == area.name }) }
-        val areas = VersionAreas(version, apis)
-        return areas
+        return Areas(apis)
     }
 
 

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/Loader.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/Loader.kt
@@ -17,7 +17,7 @@ class Loader(val namer: Namer?)  {
                 SetupType.Config -> config(it.klass, it.singleton!!, it.content, it.declared)
             }
         }
-        val areaNames = actions.map { Area(it.api.area) }.distinctBy { it.fullname }
+        val areaNames = actions.map { Area(it.api.area) }.distinctBy { it.fullName }
         val apis = areaNames.map { area -> Apis(area, actions.filter { it.api.area == area.name }) }
         val areas = VersionAreas(version, apis)
         return areas

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/Loader.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/Loader.kt
@@ -19,7 +19,7 @@ class Loader(val namer: Namer?)  {
             }
         }
         val areaNames = actions.map { Area(it.api.area) }.distinctBy { it.fullName }
-        val apis = areaNames.map { area -> Apis(area, actions.filter { it.api.area == area.name }) }
+        val apis = areaNames.map { area -> AreaApis(area, actions.filter { it.api.area == area.name }) }
         return Areas(apis)
     }
 
@@ -29,7 +29,7 @@ class Loader(val namer: Namer?)  {
      * NOTE: This allows all the API setup to be in 1 place ( in the class/members )
      *
      */
-    fun code(cls: KClass<*>, instance: Any, declared:Boolean = true ): Actions {
+    fun code(cls: KClass<*>, instance: Any, declared:Boolean = true ): ApiActions {
         val loader = AnnoLoader(cls, instance, namer)
         val api = loader.loadApi()
         val area = Area(api.area)
@@ -53,11 +53,11 @@ class Loader(val namer: Namer?)  {
             // Final mapping of route(area, api, action) -> handler
             Route(area, api, action, handler)
         }
-        return Actions(api, mappings)
+        return ApiActions(api, mappings)
     }
 
 
-    fun config(cls: KClass<*>, instance: Any, json:String = "", declared: Boolean = true): Actions {
+    fun config(cls: KClass<*>, instance: Any, json:String = "", declared: Boolean = true): ApiActions {
         val parser = JSONParser()
         val doc = parser.parse(json) as JSONObject
         val conf = ConfigLoader(cls, instance)
@@ -70,6 +70,6 @@ class Loader(val namer: Namer?)  {
 
         // Load actions from the "actions" child
         val actions = conf.loadActions(Area(api.area), api, methodMap, doc)
-        return Actions(api, actions)
+        return ApiActions(api, actions)
     }
 }

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/Setup.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/Setup.kt
@@ -4,8 +4,6 @@ import kiit.apis.SetupType
 import kiit.apis.routes.*
 import kotlin.reflect.KClass
 import kiit.utils.naming.Namer
-import kiit.meta.Reflector
-import kotlin.reflect.KVisibility
 
 
 data class ApiSetup(
@@ -27,9 +25,9 @@ fun routes(versions: List<GlobalVersion>, namer: Namer? = null) : List<VersionAr
 }
 
 
-fun router(versions: List<GlobalVersion>, namer: Namer? = null) : Router {
+fun router(versions: List<GlobalVersion>, namer: Namer? = null) : DefaultRouter {
     val versionedRoutes = routes(versions, namer)
-    return Router(versionedRoutes, namer)
+    return DefaultRouter(versionedRoutes, namer)
 }
 
 fun global(version:String, apis:List<ApiSetup>) : GlobalVersion = GlobalVersion(version, apis)

--- a/src/services/apis/src/main/kotlin/kiit/apis/setup/Setup.kt
+++ b/src/services/apis/src/main/kotlin/kiit/apis/setup/Setup.kt
@@ -15,22 +15,18 @@ data class ApiSetup(
 )
 
 
-data class GlobalVersion(val version:String, val apis:List<ApiSetup>)
-
-
-fun routes(versions: List<GlobalVersion>, namer: Namer? = null) : List<VersionAreas> {
+fun routes(all:List<ApiSetup>, namer: Namer? = null) : Areas {
     val loader =  Loader(namer)
-    val versionedRoutes = versions.map { loader.routes(it.version, it.apis) }
-    return versionedRoutes
+    val routes = loader.routes(all)
+    return routes
 }
 
 
-fun router(versions: List<GlobalVersion>, namer: Namer? = null) : DefaultRouter {
-    val versionedRoutes = routes(versions, namer)
-    return DefaultRouter(versionedRoutes, namer)
+fun router(all:List<ApiSetup>, namer: Namer? = null) : DefaultRouter {
+    val routes = routes(all, namer)
+    return DefaultRouter(routes, namer)
 }
 
-fun global(version:String, apis:List<ApiSetup>) : GlobalVersion = GlobalVersion(version, apis)
 
 fun api(klass: KClass<*>, singleton: Any?, setup: SetupType = SetupType.Annotated, declared: Boolean = true, content:String = "")
     : ApiSetup = ApiSetup(klass, singleton, setup, declared, content)


### PR DESCRIPTION
## Overview
Refactored and updated design for the following

1. API versioning
2. Route path structure
3. Router functionality
4. Routes loading

## Example
```kotlin
@Api(area = "samples", name = "greeter", version = "1", desc = "sample api", auth = AuthModes.NONE)
class Greeter(context: Context) {
    
    // Route : /samples/v1/greeter/hello
    @Action(desc = "simple hello action")
    fun hello(name:String): Outcome<User> {
         return Outcomes.success("hello ${name}")
    }
}
```

## Ticket(s) 
https://github.com/slatekit/kiit/issues/383

## Links(s) 
1. Previous work: https://github.com/slatekit/kiit/pull/360

## Dependencies
N/A

## Design
1. Removed `global versioning` at the area level ( see previous PR )
5. Versioning is only at the API level ( e.g. `/{area}/{version}/{api}/{action}` 
6. Example version : `/accounts/v1/signup/register` 
7. Simplified design of the Router and route components
8. Using Areas lookup component to map all areas
9. Using Apis lookup component to map all apis in an area
10. Using Actions lookup component to map all actions in an api
11. Defaulting version to `1` for all APIs if not supplied
12. Refactored the router loader ( renamed loader )


## Notes
1. It makes sense to only version at the API level ( collection of actions )
2. This allows changing version independently at the API level

## Pending
N/A

## Tests
1. Updated unit-tests
